### PR TITLE
Feat hierarchies

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.3
 ApproxFun 0.0.7
-
+Compat

--- a/src/GreensFun/CauchyWeight.jl
+++ b/src/GreensFun/CauchyWeight.jl
@@ -12,7 +12,7 @@ order{O}(C::CauchyWeight{O}) = O
 domain(C::CauchyWeight)=domain(C.space)
 Base.getindex(C::CauchyWeight,k::Integer)=C.space[k]
 ApproxFun.columnspace(C::CauchyWeight,::)=C[1]
-Base.getindex{O,PWS1<:PiecewiseSpace,PWS2<:PiecewiseSpace}(C::CauchyWeight{O,(PWS1,PWS2)},i::Integer,j::Integer)=CauchyWeight(C[1][i]⊗C[2][j],O)
+Base.getindex{O,PWS1<:PiecewiseSpace,PWS2<:PiecewiseSpace}(C::CauchyWeight{O,(PWS1,PWS2)},i,j)=CauchyWeight(C.space[i,j],O)
 Base.transpose{O}(C::CauchyWeight{O}) = CauchyWeight(transpose(C.space),O)
 
 cauchyweight(O,x,y) = O == 0 ? logabs(y-x)/π : (y-x).^(-O)/π

--- a/src/LinearAlgebra/HierarchicalMatrix.jl
+++ b/src/LinearAlgebra/HierarchicalMatrix.jl
@@ -1,0 +1,65 @@
+
+
+##
+# Represent a power-of-two hierarchical matrix
+# [ x x \ /
+#   x x / \
+#   \ / x x
+#   / \ x x ]
+# ordering the data from the main diagonal outward
+# starting with the lower block
+##
+
+export HierarchicalMatrix
+
+type HierarchicalMatrix{T} <: AbstractSparseMatrix{T,Int}
+    diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})) # n ≥ 2 ? Tuple of two on-diagonal HierarchicalMatrix{T} : Tuple of two on-diagonal T
+    offdiagonaldata::@compat(Tuple{T,T}) # Tuple of two off-diagonal T
+    n::Int # Power of hierarchy (i.e. 2^n)
+    function HierarchicalMatrix(data::Vector{T},n::Int)
+        @assert length(data) == 3*2^n-2
+        if n == 1
+            return new((data[1],data[2]),(data[3],data[4]),n)
+        elseif n ≥ 2
+            data1,data2 = dividedata(data,n)
+            return new((HierarchicalMatrix(data1,n-1),HierarchicalMatrix(data2,n-1)),(data[end-1],data[end]),n)
+        end
+    end
+end
+
+function dividedata{T}(data::Vector{T},n::Int)
+    data1,data2 = Array(T,3*2^(n-1)-2),Array(T,3*2^(n-1)-2)
+    k,k1,k2 = 1,1,1
+    for j=1:2^(n-1)
+        data1[k1] = data[k]
+        k1+=1
+        k+=1
+    end
+    for j=1:2^(n-1)
+        data2[k2] = data[k]
+        k2+=1
+        k+=1
+    end
+    for i = n-1:-1:1
+        for j=1:2^i
+            data1[k1] = data[k]
+            k1+=1
+            k+=1
+        end
+        for j=1:2^i
+            data2[k2] = data[k]
+            k2+=1
+            k+=1
+        end
+    end
+    data1,data2
+end
+
+HierarchicalMatrix{T}(data::Vector{T},n::Integer)=HierarchicalMatrix{T}(data,n)
+HierarchicalMatrix{T}(data::Vector{T})=HierarchicalMatrix(data,round(Int,log2(div(length(data)+2,3))))
+
+
+Base.eltype{T}(::HierarchicalMatrix{T})=T
+Base.convert{V}(::Type{HierarchicalMatrix{V}},M::HierarchicalMatrix) = HierarchicalMatrix{V}(convert(Vector{V},M.data),M.n)
+
+Base.promote_rule{T,V}(::Type{HierarchicalMatrix{T}},::Type{HierarchicalMatrix{V}})=HierarchicalMatrix{promote_type(T,V)}

--- a/src/LinearAlgebra/HierarchicalMatrix.jl
+++ b/src/LinearAlgebra/HierarchicalMatrix.jl
@@ -7,74 +7,61 @@
 #   \ / x x
 #   / \ x x ]
 # where the diagonal blocks are of the same type.
+# To have simple recursive construction, we use the ordering:
+# [ 5   4
+#     ⋯      2
+#   3   6
+#          9   8
+#     1      ⋯
+#          7   10 ]
 ##
 
 export HierarchicalMatrix, partitionmatrix
 
 type HierarchicalMatrix{T} <: AbstractSparseMatrix{T,Int}
-    diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})) # n ≥ 2 ? Tuple of two on-diagonal HierarchicalMatrix{T} : Tuple of two on-diagonal T
     offdiagonaldata::@compat(Tuple{T,T}) # Tuple of two off-diagonal T
+    diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})) # n ≥ 2 ? Tuple of two on-diagonal HierarchicalMatrix{T} : Tuple of two on-diagonal T
     n::Int # Power of hierarchy (i.e. 2^n)
+
     function HierarchicalMatrix(data::Vector{T},n::Int)
         @assert length(data) == 3*2^n-2
         if n == 0
-            return data[1]
+            return data[1] ## TODO: not type-stable
         elseif n == 1
             return new((data[1],data[2]),(data[3],data[4]),n)
         elseif n ≥ 2
-            p1,p2 = setpartition(n)
-            return new((HierarchicalMatrix(data[p1],n-1),HierarchicalMatrix(data[p2],n-1)),(data[end-1],data[end]),n)
+            dldp2 = div(length(data)+2,2)
+            return new((data[1],data[2]),(HierarchicalMatrix(data[3:dldp2],n-1),HierarchicalMatrix(data[dldp2+1:end],n-1)),n)
         end
     end
-end
-
-function setpartition(n::Int)
-    p1,p2 = Array(Int,3*2^(n-1)-2),Array(Int,3*2^(n-1)-2)
-    k,k1,k2 = 1,1,1
-    for j=1:2^(n-1)
-        p1[k1] = k
-        k1+=1
-        k+=1
-    end
-    for j=1:2^(n-1)
-        p2[k2] = k
-        k2+=1
-        k+=1
-    end
-    for i = n-1:-1:1
-        for j=1:2^i
-            p1[k1] = k
-            k1+=1
-            k+=1
-        end
-        for j=1:2^i
-            p2[k2] = k
-            k2+=1
-            k+=1
-        end
-    end
-    p1,p2
 end
 
 HierarchicalMatrix{T}(data::Vector{T},n::Integer)=HierarchicalMatrix{T}(data,n)
 HierarchicalMatrix{T}(data::Vector{T})=HierarchicalMatrix(data,round(Int,log2(div(length(data)+2,3))))
 
+function collectdata{T}(H::HierarchicalMatrix{T})
+    data = collect(H.offdiagonaldata)
+    if H.n == 1
+        push!(data,H.diagonaldata...)
+    elseif H.n ≥ 2
+        append!(data,mapreduce(collectdata,vcat,H.diagonaldata))
+    end
+    data
+end
 
 Base.eltype{T}(::HierarchicalMatrix{T})=T
-#Base.convert{V}(::Type{HierarchicalMatrix{V}},M::HierarchicalMatrix) = HierarchicalMatrix{V}(convert(Vector{V},M.data),M.n)
-
+Base.convert{V}(::Type{HierarchicalMatrix{V}},M::HierarchicalMatrix) = HierarchicalMatrix{V}(convert(Vector{V},collectdata(M)),M.n)
 Base.promote_rule{T,V}(::Type{HierarchicalMatrix{T}},::Type{HierarchicalMatrix{V}})=HierarchicalMatrix{promote_type(T,V)}
 
-partitionmatrix{T}(H::HierarchicalMatrix{T}) = (H.diagonaldata),(H.offdiagonaldata)
+function Base.size{T<:AbstractMatrix}(H::HierarchicalMatrix{T})
+    m1,n1 = size(H.offdiagonaldata[1])
+    m2,n2 = size(H.offdiagonaldata[2])
+    m1+m2,n1+n2
+end
 
-
-
-Base.size{T}(H::HierarchicalMatrix{AbstractArray{T,2}},k) = k==1? size(H.diagonaldata[1],k)+size(H.offdiagonaldata[1],k) : k == 2? size(H.diagonaldata[1],k)+size(H.offdiagonaldata[2],k) : Nothing
-Base.size{T}(H::HierarchicalMatrix{AbstractArray{T,2}}) = size(H,1),size(H,2)
-
-function Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},i::Int,j::Int)
-    m1,n1 = size(H.diagonaldata[1])
-    m2,n2 = size(H.diagonaldata[2])
+function Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,j::Int)
+    m1,n1 = size(H.offdiagonaldata[1])
+    m2,n2 = size(H.offdiagonaldata[2])
     if 1 ≤ i ≤ m1
         if 1 ≤ j ≤ n1
             return getindex(H.diagonaldata[1],i,j)
@@ -89,14 +76,16 @@ function Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},i::Int,j::In
         end
     end
 end
-Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},i::Int,jr::Range) = transpose(T[H[i,j] for j=jr])
-Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},ir::Range,j::Int) = T[H[i,j] for i=ir]
-Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},ir::Range,jr::Range) = T[H[i,j] for i=ir,j=jr]
-Base.full{T}(H::HierarchicalMatrix{AbstractArray{T,2}})=H[1:size(H,1),1:size(H,2)]
+Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,jr::Range) = transpose(eltype(T)[H[i,j] for j=jr])
+Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},ir::Range,j::Int) = eltype(T)[H[i,j] for i=ir]
+Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},ir::Range,jr::Range) = eltype(T)[H[i,j] for i=ir,j=jr]
+Base.full{T<:AbstractMatrix}(H::HierarchicalMatrix{T})=H[1:size(H,1),1:size(H,2)]
 
-function *{S,T}(H::HierarchicalMatrix{AbstractArray{S,2}},b::Vector{T})
+partitionmatrix{T}(H::HierarchicalMatrix{T}) = H.diagonaldata,H.offdiagonaldata
+
+function *{S,T}(H::HierarchicalMatrix{S},b::AbstractVecOrMat{T})
     m1,m2 = size(H.diagonaldata[1],1),size(H.offdiagonaldata[1],1)
     (b1,b2) = (b[1:m1],b[1+m1:m1+m2])
     vcat(H.diagonaldata[1]*b1+H.offdiagonaldata[2]*b2,H.offdiagonaldata[1]*b1+H.diagonaldata[2]*b2)
 end
-\{S,T}(H::HierarchicalMatrix{AbstractArray{S,2}},b::VecOrMat{T}) = full(H)\b
+\{S,T}(H::HierarchicalMatrix{S},b::AbstractVecOrMat{T}) = full(H)\b

--- a/src/LinearAlgebra/HierarchicalMatrix.jl
+++ b/src/LinearAlgebra/HierarchicalMatrix.jl
@@ -9,7 +9,7 @@
 # where the diagonal blocks are of the same type.
 ##
 
-export HierarchicalMatrix
+export HierarchicalMatrix, partitionmatrix
 
 type HierarchicalMatrix{T} <: AbstractSparseMatrix{T,Int}
     diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})) # n ≥ 2 ? Tuple of two on-diagonal HierarchicalMatrix{T} : Tuple of two on-diagonal T
@@ -17,41 +17,43 @@ type HierarchicalMatrix{T} <: AbstractSparseMatrix{T,Int}
     n::Int # Power of hierarchy (i.e. 2^n)
     function HierarchicalMatrix(data::Vector{T},n::Int)
         @assert length(data) == 3*2^n-2
-        if n == 1
+        if n == 0
+            return data[1]
+        elseif n == 1
             return new((data[1],data[2]),(data[3],data[4]),n)
         elseif n ≥ 2
-            data1,data2 = dividedata(data,n)
-            return new((HierarchicalMatrix(data1,n-1),HierarchicalMatrix(data2,n-1)),(data[end-1],data[end]),n)
+            p1,p2 = setpartition(n)
+            return new((HierarchicalMatrix(data[p1],n-1),HierarchicalMatrix(data[p2],n-1)),(data[end-1],data[end]),n)
         end
     end
 end
 
-function dividedata{T}(data::Vector{T},n::Int)
-    data1,data2 = Array(T,3*2^(n-1)-2),Array(T,3*2^(n-1)-2)
+function setpartition(n::Int)
+    p1,p2 = Array(Int,3*2^(n-1)-2),Array(Int,3*2^(n-1)-2)
     k,k1,k2 = 1,1,1
     for j=1:2^(n-1)
-        data1[k1] = data[k]
+        p1[k1] = k
         k1+=1
         k+=1
     end
     for j=1:2^(n-1)
-        data2[k2] = data[k]
+        p2[k2] = k
         k2+=1
         k+=1
     end
     for i = n-1:-1:1
         for j=1:2^i
-            data1[k1] = data[k]
+            p1[k1] = k
             k1+=1
             k+=1
         end
         for j=1:2^i
-            data2[k2] = data[k]
+            p2[k2] = k
             k2+=1
             k+=1
         end
     end
-    data1,data2
+    p1,p2
 end
 
 HierarchicalMatrix{T}(data::Vector{T},n::Integer)=HierarchicalMatrix{T}(data,n)
@@ -59,6 +61,42 @@ HierarchicalMatrix{T}(data::Vector{T})=HierarchicalMatrix(data,round(Int,log2(di
 
 
 Base.eltype{T}(::HierarchicalMatrix{T})=T
-Base.convert{V}(::Type{HierarchicalMatrix{V}},M::HierarchicalMatrix) = HierarchicalMatrix{V}(convert(Vector{V},M.data),M.n)
+#Base.convert{V}(::Type{HierarchicalMatrix{V}},M::HierarchicalMatrix) = HierarchicalMatrix{V}(convert(Vector{V},M.data),M.n)
 
 Base.promote_rule{T,V}(::Type{HierarchicalMatrix{T}},::Type{HierarchicalMatrix{V}})=HierarchicalMatrix{promote_type(T,V)}
+
+partitionmatrix{T}(H::HierarchicalMatrix{T}) = (H.diagonaldata),(H.offdiagonaldata)
+
+
+
+Base.size{T}(H::HierarchicalMatrix{AbstractArray{T,2}},k) = k==1? size(H.diagonaldata[1],k)+size(H.offdiagonaldata[1],k) : k == 2? size(H.diagonaldata[1],k)+size(H.offdiagonaldata[2],k) : Nothing
+Base.size{T}(H::HierarchicalMatrix{AbstractArray{T,2}}) = size(H,1),size(H,2)
+
+function Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},i::Int,j::Int)
+    m1,n1 = size(H.diagonaldata[1])
+    m2,n2 = size(H.diagonaldata[2])
+    if 1 ≤ i ≤ m1
+        if 1 ≤ j ≤ n1
+            return getindex(H.diagonaldata[1],i,j)
+        elseif n1 < j ≤ n1+n2
+            return getindex(H.offdiagonaldata[2],i,j-n1)
+        end
+    elseif m1 < i ≤ m1+m2
+        if 1 ≤ j ≤ n1
+            return getindex(H.offdiagonaldata[1],i-m1,j)
+        elseif n1 < j ≤ n1+n2
+            return getindex(H.diagonaldata[2],i-m1,j-n1)
+        end
+    end
+end
+Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},i::Int,jr::Range) = transpose(T[H[i,j] for j=jr])
+Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},ir::Range,j::Int) = T[H[i,j] for i=ir]
+Base.getindex{T}(H::HierarchicalMatrix{AbstractArray{T,2}},ir::Range,jr::Range) = T[H[i,j] for i=ir,j=jr]
+Base.full{T}(H::HierarchicalMatrix{AbstractArray{T,2}})=H[1:size(H,1),1:size(H,2)]
+
+function *{S,T}(H::HierarchicalMatrix{AbstractArray{S,2}},b::Vector{T})
+    m1,m2 = size(H.diagonaldata[1],1),size(H.offdiagonaldata[1],1)
+    (b1,b2) = (b[1:m1],b[1+m1:m1+m2])
+    vcat(H.diagonaldata[1]*b1+H.offdiagonaldata[2]*b2,H.offdiagonaldata[1]*b1+H.diagonaldata[2]*b2)
+end
+\{S,T}(H::HierarchicalMatrix{AbstractArray{S,2}},b::VecOrMat{T}) = full(H)\b

--- a/src/LinearAlgebra/HierarchicalMatrix.jl
+++ b/src/LinearAlgebra/HierarchicalMatrix.jl
@@ -6,8 +6,7 @@
 #   x x / \
 #   \ / x x
 #   / \ x x ]
-# ordering the data from the main diagonal outward
-# starting with the lower block
+# where the diagonal blocks are of the same type.
 ##
 
 export HierarchicalMatrix

--- a/src/LinearAlgebra/HierarchicalMatrix.jl
+++ b/src/LinearAlgebra/HierarchicalMatrix.jl
@@ -18,54 +18,66 @@
 
 export HierarchicalMatrix, partitionmatrix
 
-type HierarchicalMatrix{T} <: AbstractSparseMatrix{T,Int}
+# TODO: how to extract the element-types of S and T into the Abstract supertype?
+
+type HierarchicalMatrix{S,T} <: AbstractMatrix{promote_type(S,T)}
+    diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{S,T},HierarchicalMatrix{S,T}}),@compat(Tuple{S,S})) # n ≥ 2 ? Tuple of two on-diagonal HierarchicalMatrix{S,T} : Tuple of two on-diagonal S
     offdiagonaldata::@compat(Tuple{T,T}) # Tuple of two off-diagonal T
-    diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})) # n ≥ 2 ? Tuple of two on-diagonal HierarchicalMatrix{T} : Tuple of two on-diagonal T
     n::Int # Power of hierarchy (i.e. 2^n)
 
-    function HierarchicalMatrix(data::Vector{T},n::Int)
-        @assert length(data) == 3*2^n-2
-        if n == 0
-            return data[1] ## TODO: not type-stable
-        elseif n == 1
-            return new((data[1],data[2]),(data[3],data[4]),n)
+    function HierarchicalMatrix(diagonaldata::Vector{S},offdiagonaldata::Vector{T},n::Int)
+        @assert length(diagonaldata) == 2^n
+        @assert length(offdiagonaldata) == 2^(n+1)-2
+        if n == 1
+            return new(tuple(diagonaldata...),tuple(offdiagonaldata...),n)
         elseif n ≥ 2
-            dldp2 = div(length(data)+2,2)
-            return new((data[1],data[2]),(HierarchicalMatrix(data[3:dldp2],n-1),HierarchicalMatrix(data[dldp2+1:end],n-1)),n)
+            dldp2 = div(length(offdiagonaldata)+2,2)
+            return new((HierarchicalMatrix(diagonaldata[1:2^(n-1)],offdiagonaldata[3:dldp2],n-1),HierarchicalMatrix(diagonaldata[1+2^(n-1):end],offdiagonaldata[dldp2+1:end],n-1)),(offdiagonaldata[1],offdiagonaldata[2]),n)
         end
     end
-    HierarchicalMatrix(offdiagonaldata::@compat(Tuple{T,T}),diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})),n::Int) = new(offdiagonaldata,diagonaldata,n)
+    HierarchicalMatrix(diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{S,T},HierarchicalMatrix{S,T}}),@compat(Tuple{S,S})),offdiagonaldata::@compat(Tuple{T,T}),n::Int) = new(diagonaldata,offdiagonaldata,n)
 end
 
-HierarchicalMatrix{T}(offdiagonaldata::@compat(Tuple{T,T}),diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})),n::Int) = HierarchicalMatrix{T}(offdiagonaldata,diagonaldata,n)
+HierarchicalMatrix{S,T}(diagonaldata::Vector{S},offdiagonaldata::Vector{T},n::Int)=HierarchicalMatrix{S,T}(diagonaldata,offdiagonaldata,n)
+HierarchicalMatrix{S,T}(diagonaldata::Vector{S},offdiagonaldata::Vector{T})=HierarchicalMatrix(diagonaldata,offdiagonaldata,round(Int,log2(length(diagonaldata))))
 
-HierarchicalMatrix{T}(data::Vector{T},n::Int)=HierarchicalMatrix{T}(data,n)
-HierarchicalMatrix{T}(data::Vector{T})=HierarchicalMatrix(data,round(Int,log2(div(length(data)+2,3))))
+HierarchicalMatrix{S,T}(diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{S,T},HierarchicalMatrix{S,T}}),@compat(Tuple{S,S})),offdiagonaldata::@compat(Tuple{T,T}),n::Int) = HierarchicalMatrix{S,T}(diagonaldata,offdiagonaldata,n)
+HierarchicalMatrix{S,T}(diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{S,T},HierarchicalMatrix{S,T}}),@compat(Tuple{S,S})),offdiagonaldata::@compat(Tuple{T,T})) = HierarchicalMatrix(diagonaldata,offdiagonaldata,round(Int,log2(length(diagonaldata))))
 
-function collectdata{T}(H::HierarchicalMatrix{T})
+
+function collectoffdiagonaldata{S,T}(H::HierarchicalMatrix{S,T})
     data = collect(H.offdiagonaldata)
-    if H.n == 1
-        push!(data,H.diagonaldata...)
-    elseif H.n ≥ 2
-        append!(data,mapreduce(collectdata,vcat,H.diagonaldata))
+    if H.n ≥ 2
+        append!(data,mapreduce(collectoffdiagonaldata,vcat,H.diagonaldata))
     end
     data
 end
 
-Base.eltype{T}(::HierarchicalMatrix{T})=T
-Base.convert{V}(::Type{HierarchicalMatrix{V}},M::HierarchicalMatrix) = HierarchicalMatrix{V}(convert(Vector{V},collectdata(M)),M.n)
-Base.promote_rule{T,V}(::Type{HierarchicalMatrix{T}},::Type{HierarchicalMatrix{V}})=HierarchicalMatrix{promote_type(T,V)}
+function collectdiagonaldata{S,T}(H::HierarchicalMatrix{S,T})
+    data = S[]
+    if H.n == 1
+        push!(data,H.diagonaldata...)
+    elseif H.n ≥ 2
+        append!(data,mapreduce(collectdiagonaldata,vcat,H.diagonaldata))
+    end
+    data
+end
 
-Base.transpose(H::HierarchicalMatrix) = HierarchicalMatrix(map(transpose,reverse(H.offdiagonaldata)),map(transpose,H.diagonaldata),H.n)
-Base.ctranspose(H::HierarchicalMatrix) = HierarchicalMatrix(map(ctranspose,reverse(H.offdiagonaldata)),map(ctranspose,H.diagonaldata),H.n)
 
-function Base.size{T<:AbstractMatrix}(H::HierarchicalMatrix{T})
+Base.eltype{S,T}(::HierarchicalMatrix{S,T})=promote_type(eltype(S),eltype(T))
+Base.convert{U,V}(::Type{HierarchicalMatrix{U,V}},M::HierarchicalMatrix) = HierarchicalMatrix{U,V}(convert(Vector{U},collectdiagonaldata(M)),convert(Vector{V},collectoffdiagonaldata(M)),M.n)
+Base.promote_rule{S,T,U,V}(::Type{HierarchicalMatrix{S,T}},::Type{HierarchicalMatrix{U,V}})=HierarchicalMatrix{promote_type(S,U),promote_type(T,V)}
+
+Base.transpose(H::HierarchicalMatrix) = HierarchicalMatrix(map(transpose,H.diagonaldata),map(transpose,reverse(H.offdiagonaldata)),H.n)
+Base.ctranspose(H::HierarchicalMatrix) = HierarchicalMatrix(map(ctranspose,H.diagonaldata),map(ctranspose,reverse(H.offdiagonaldata)),H.n)
+
+function Base.size{S<:AbstractMatrix,T<:AbstractMatrix}(H::HierarchicalMatrix{S,T})
     m1,n1 = size(H.offdiagonaldata[2])
     m2,n2 = size(H.offdiagonaldata[1])
     m1+m2,n1+n2
 end
 
-function Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,j::Int)
+function Base.getindex{S<:AbstractMatrix,T<:AbstractMatrix}(H::HierarchicalMatrix{S,T},i::Int,j::Int)
     m1,n1 = size(H.offdiagonaldata[2])
     m2,n2 = size(H.offdiagonaldata[1])
     if 1 ≤ i ≤ m1
@@ -82,16 +94,19 @@ function Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,j::Int
         end
     end
 end
-Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,jr::Range) = eltype(T)[H[i,j] for j=jr].'#'
-Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},ir::Range,j::Int) = eltype(T)[H[i,j] for i=ir]
-Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},ir::Range,jr::Range) = eltype(T)[H[i,j] for i=ir,j=jr]
-Base.full{T<:AbstractMatrix}(H::HierarchicalMatrix{T})=H[1:size(H,1),1:size(H,2)]
+Base.getindex{S<:AbstractMatrix,T<:AbstractMatrix}(H::HierarchicalMatrix{S,T},i::Int,jr::Range) = eltype(H)[H[i,j] for j=jr].'#'
+Base.getindex{S<:AbstractMatrix,T<:AbstractMatrix}(H::HierarchicalMatrix{S,T},ir::Range,j::Int) = eltype(H)[H[i,j] for i=ir]
+Base.getindex{S<:AbstractMatrix,T<:AbstractMatrix}(H::HierarchicalMatrix{S,T},ir::Range,jr::Range) = eltype(H)[H[i,j] for i=ir,j=jr]
+Base.full{S<:AbstractMatrix,T<:AbstractMatrix}(H::HierarchicalMatrix{S,T})=H[1:size(H,1),1:size(H,2)]
 
-partitionmatrix{T}(H::HierarchicalMatrix{T}) = H.diagonaldata,H.offdiagonaldata
+partitionmatrix{S,T}(H::HierarchicalMatrix{S,T}) = H.diagonaldata,H.offdiagonaldata
 
-function *{S,T}(H::HierarchicalMatrix{S},b::AbstractVecOrMat{T})
+function *{S,T,V}(H::HierarchicalMatrix{S,T},b::AbstractVecOrMat{V})
     m1,m2 = size(H.offdiagonaldata[2],1),size(H.offdiagonaldata[1],1)
-    (b1,b2) = (b[1:m1],b[1+m1:m1+m2])
+    n = size(b,2)
+    (b1,b2) = (b[1:m1,1:n],b[1+m1:m1+m2,1:n])
     vcat(H.diagonaldata[1]*b1+H.offdiagonaldata[2]*b2,H.offdiagonaldata[1]*b1+H.diagonaldata[2]*b2)
 end
-\{S,T}(H::HierarchicalMatrix{S},b::AbstractVecOrMat{T}) = full(H)\b
+
+\{S,T,V}(H::HierarchicalMatrix{S,T},b::AbstractVecOrMat{V}) = full(H)\b
+\{S<:AbstractMatrix,T<:LowRankMatrix,V}(H::HierarchicalMatrix{S,T},f::AbstractVecOrMat{V}) = woodburysolve(H,f)

--- a/src/LinearAlgebra/HierarchicalMatrix.jl
+++ b/src/LinearAlgebra/HierarchicalMatrix.jl
@@ -34,9 +34,12 @@ type HierarchicalMatrix{T} <: AbstractSparseMatrix{T,Int}
             return new((data[1],data[2]),(HierarchicalMatrix(data[3:dldp2],n-1),HierarchicalMatrix(data[dldp2+1:end],n-1)),n)
         end
     end
+    HierarchicalMatrix(offdiagonaldata::@compat(Tuple{T,T}),diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})),n::Int) = new(offdiagonaldata,diagonaldata,n)
 end
 
-HierarchicalMatrix{T}(data::Vector{T},n::Integer)=HierarchicalMatrix{T}(data,n)
+HierarchicalMatrix{T}(offdiagonaldata::@compat(Tuple{T,T}),diagonaldata::Union(@compat(Tuple{HierarchicalMatrix{T},HierarchicalMatrix{T}}),@compat(Tuple{T,T})),n::Int) = HierarchicalMatrix{T}(offdiagonaldata,diagonaldata,n)
+
+HierarchicalMatrix{T}(data::Vector{T},n::Int)=HierarchicalMatrix{T}(data,n)
 HierarchicalMatrix{T}(data::Vector{T})=HierarchicalMatrix(data,round(Int,log2(div(length(data)+2,3))))
 
 function collectdata{T}(H::HierarchicalMatrix{T})
@@ -53,15 +56,18 @@ Base.eltype{T}(::HierarchicalMatrix{T})=T
 Base.convert{V}(::Type{HierarchicalMatrix{V}},M::HierarchicalMatrix) = HierarchicalMatrix{V}(convert(Vector{V},collectdata(M)),M.n)
 Base.promote_rule{T,V}(::Type{HierarchicalMatrix{T}},::Type{HierarchicalMatrix{V}})=HierarchicalMatrix{promote_type(T,V)}
 
+Base.transpose(H::HierarchicalMatrix) = HierarchicalMatrix(map(transpose,reverse(H.offdiagonaldata)),map(transpose,H.diagonaldata),H.n)
+Base.ctranspose(H::HierarchicalMatrix) = HierarchicalMatrix(map(ctranspose,reverse(H.offdiagonaldata)),map(ctranspose,H.diagonaldata),H.n)
+
 function Base.size{T<:AbstractMatrix}(H::HierarchicalMatrix{T})
-    m1,n1 = size(H.offdiagonaldata[1])
-    m2,n2 = size(H.offdiagonaldata[2])
+    m1,n1 = size(H.offdiagonaldata[2])
+    m2,n2 = size(H.offdiagonaldata[1])
     m1+m2,n1+n2
 end
 
 function Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,j::Int)
-    m1,n1 = size(H.offdiagonaldata[1])
-    m2,n2 = size(H.offdiagonaldata[2])
+    m1,n1 = size(H.offdiagonaldata[2])
+    m2,n2 = size(H.offdiagonaldata[1])
     if 1 ≤ i ≤ m1
         if 1 ≤ j ≤ n1
             return getindex(H.diagonaldata[1],i,j)
@@ -76,7 +82,7 @@ function Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,j::Int
         end
     end
 end
-Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,jr::Range) = transpose(eltype(T)[H[i,j] for j=jr])
+Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},i::Int,jr::Range) = eltype(T)[H[i,j] for j=jr].'#'
 Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},ir::Range,j::Int) = eltype(T)[H[i,j] for i=ir]
 Base.getindex{T<:AbstractMatrix}(H::HierarchicalMatrix{T},ir::Range,jr::Range) = eltype(T)[H[i,j] for i=ir,j=jr]
 Base.full{T<:AbstractMatrix}(H::HierarchicalMatrix{T})=H[1:size(H,1),1:size(H,2)]
@@ -84,7 +90,7 @@ Base.full{T<:AbstractMatrix}(H::HierarchicalMatrix{T})=H[1:size(H,1),1:size(H,2)
 partitionmatrix{T}(H::HierarchicalMatrix{T}) = H.diagonaldata,H.offdiagonaldata
 
 function *{S,T}(H::HierarchicalMatrix{S},b::AbstractVecOrMat{T})
-    m1,m2 = size(H.diagonaldata[1],1),size(H.offdiagonaldata[1],1)
+    m1,m2 = size(H.offdiagonaldata[2],1),size(H.offdiagonaldata[1],1)
     (b1,b2) = (b[1:m1],b[1+m1:m1+m2])
     vcat(H.diagonaldata[1]*b1+H.offdiagonaldata[2]*b2,H.offdiagonaldata[1]*b1+H.diagonaldata[2]*b2)
 end

--- a/src/LinearAlgebra/LinearAlgebra.jl
+++ b/src/LinearAlgebra/LinearAlgebra.jl
@@ -1,0 +1,2 @@
+include("LowRankMatrix.jl")
+include("HierarchicalMatrix.jl")

--- a/src/LinearAlgebra/LinearAlgebra.jl
+++ b/src/LinearAlgebra/LinearAlgebra.jl
@@ -1,2 +1,3 @@
 include("LowRankMatrix.jl")
 include("HierarchicalMatrix.jl")
+include("woodburysolve.jl")

--- a/src/LinearAlgebra/LowRankMatrix.jl
+++ b/src/LinearAlgebra/LowRankMatrix.jl
@@ -1,0 +1,61 @@
+import ApproxFun: eps
+
+##
+# Represent an m x n rank-r matrix
+# A = U V^T
+##
+
+export LowRankMatrix
+
+type LowRankMatrix{T} <: AbstractSparseMatrix{T,Int}
+    U::Matrix{T} # m x r Matrix
+    V::Matrix{T} # n x r Matrix
+    m::Int
+    n::Int
+    r::Int
+    function LowRankMatrix(U::Matrix{T},V::Matrix{T},m::Int,n::Int,r::Int)
+        mu,ru = size(U)
+        nv,rv = size(V)
+        @assert ru == rv == r
+        @assert mu ≤ m
+        @assert nv ≤ n
+        new(pad(U,m,r),pad(V,n,r),m,n,r)
+    end
+    LowRankMatrix(U::Matrix{T},V::Matrix{T}) = new(U,V,size(U)[1],size(V)[1],size(V)[2])
+end
+
+LowRankMatrix{T}(U::Matrix{T},V::Matrix{T},m::Int,n::Int)=LowRankMatrix{T}(U,V,m,n,size(V)[2])
+LowRankMatrix{T}(U::Matrix{T},V::Matrix{T})=LowRankMatrix{T}(U,V)
+
+function LowRankMatrix{S,T}(U::Matrix{S},V::Matrix{T})
+    R = promote_type(S,T)
+    LowRankMatrix(convert(Matrix{R},U),convert(Matrix{R},V))
+end
+
+function LowRankMatrix{T}(A::Matrix{T})
+    U,Σ,V=svd(A)
+    r=max(1,count(s->s>10eps(T),Σ))
+    for k=1:r
+        U[:,k] .*= sqrt(Σ[k])
+        V[:,k] = conj(V[:,k]).*sqrt(Σ[k])
+    end
+    LowRankMatrix(U[:,1:r],V[:,1:r])
+end
+
+
+
+Base.eltype{T}(::LowRankMatrix{T})=T
+Base.convert{T}(::Type{LowRankMatrix{T}},M::LowRankMatrix) = LowRankMatrix{T}(convert(Matrix{T},M.U),convert(Matrix{T},M.V))
+
+Base.promote_rule{T,V}(::Type{LowRankMatrix{T}},::Type{LowRankMatrix{V}})=LowRankMatrix{promote_type(T,V)}
+
+Base.size(L::LowRankMatrix,k) = k==1? L.m : k == 2? L.n : Nothing
+Base.size(L::LowRankMatrix) = L.m,L.n
+Base.rank(L::LowRankMatrix) = L.r
+Base.getindex(L::LowRankMatrix,i::Int,j::Int) = mapreduce(k->L.U[i,k]*L.V[j,k],+,1:L.r)
+Base.getindex{T}(L::LowRankMatrix{T},i::Int,jr::Range) = transpose(T[L[i,j] for j=jr])
+Base.getindex{T}(L::LowRankMatrix{T},ir::Range,j::Int) = T[L[i,j] for i=ir]
+Base.getindex{T}(L::LowRankMatrix{T},ir::Range,jr::Range) = T[L[i,j] for i=ir,j=jr]
+Base.full(L::LowRankMatrix)=L[1:L.m,1:L.n]
+
+*{S,T}(L::LowRankMatrix{S},v::Vector{T}) = mapreduce(k->L.U[:,k]*dotu(L.V[:,k],v),+,1:L.r)

--- a/src/LinearAlgebra/LowRankMatrix.jl
+++ b/src/LinearAlgebra/LowRankMatrix.jl
@@ -59,3 +59,4 @@ Base.getindex{T}(L::LowRankMatrix{T},ir::Range,jr::Range) = T[L[i,j] for i=ir,j=
 Base.full(L::LowRankMatrix)=L[1:L.m,1:L.n]
 
 *{S,T}(L::LowRankMatrix{S},v::Vector{T}) = mapreduce(k->L.U[:,k]*dotu(L.V[:,k],v),+,1:L.r)
+\{S,T}(L::LowRankMatrix{S},b::VecOrMat{T}) = full(L)\b

--- a/src/LinearAlgebra/LowRankMatrix.jl
+++ b/src/LinearAlgebra/LowRankMatrix.jl
@@ -13,6 +13,7 @@ type LowRankMatrix{T} <: AbstractSparseMatrix{T,Int}
     m::Int
     n::Int
     r::Int
+
     function LowRankMatrix(U::Matrix{T},V::Matrix{T},m::Int,n::Int,r::Int)
         mu,ru = size(U)
         nv,rv = size(V)
@@ -46,10 +47,9 @@ end
 
 Base.eltype{T}(::LowRankMatrix{T})=T
 Base.convert{T}(::Type{LowRankMatrix{T}},M::LowRankMatrix) = LowRankMatrix{T}(convert(Matrix{T},M.U),convert(Matrix{T},M.V))
-
+Base.convert{T}(::Type{Matrix{T}},M::LowRankMatrix) = convert(Matrix{T},full(M))
 Base.promote_rule{T,V}(::Type{LowRankMatrix{T}},::Type{LowRankMatrix{V}})=LowRankMatrix{promote_type(T,V)}
 
-Base.size(L::LowRankMatrix,k) = k==1? L.m : k == 2? L.n : Nothing
 Base.size(L::LowRankMatrix) = L.m,L.n
 Base.rank(L::LowRankMatrix) = L.r
 Base.getindex(L::LowRankMatrix,i::Int,j::Int) = mapreduce(k->L.U[i,k]*L.V[j,k],+,1:L.r)

--- a/src/LinearAlgebra/LowRankMatrix.jl
+++ b/src/LinearAlgebra/LowRankMatrix.jl
@@ -1,4 +1,4 @@
-import ApproxFun: eps
+
 
 ##
 # Represent an m x n rank-r matrix
@@ -7,7 +7,7 @@ import ApproxFun: eps
 
 export LowRankMatrix
 
-type LowRankMatrix{T} <: AbstractSparseMatrix{T,Int}
+type LowRankMatrix{T} <: AbstractMatrix{T}
     U::Matrix{T} # m x r Matrix
     V::Matrix{T} # n x r Matrix
     m::Int
@@ -63,5 +63,5 @@ Base.getindex{T}(L::LowRankMatrix{T},ir::Range,j::Int) = T[L[i,j] for i=ir]
 Base.getindex{T}(L::LowRankMatrix{T},ir::Range,jr::Range) = T[L[i,j] for i=ir,j=jr]
 Base.full(L::LowRankMatrix)=L[1:L.m,1:L.n]
 
-*{S,T}(L::LowRankMatrix{S},v::AbstractVecOrMat{T}) = L.U*(L.V.'*v)#'
+*{S,T}(L::LowRankMatrix{S},b::AbstractVecOrMat{T}) = L.U*(L.V.'*b)#'
 \{S,T}(L::LowRankMatrix{S},b::AbstractVecOrMat{T}) = full(L)\b

--- a/src/LinearAlgebra/woodburysolve.jl
+++ b/src/LinearAlgebra/woodburysolve.jl
@@ -1,0 +1,53 @@
+#
+# woodburysolve
+#
+
+woodburysolve{S<:AbstractMatrix,V}(H::S,f::AbstractVecOrMat{V}) = H\f
+
+function woodburysolve{S<:AbstractMatrix,U<:LowRankMatrix,V}(H::HierarchicalMatrix{S,U},f::AbstractVecOrMat{V})
+    T,nf = promote_type(eltype(H),V),size(f,2)
+
+    # Partition HierarchicalMatrix
+
+    (H11,H22),(H21,H12) = partitionmatrix(H)
+
+    # Off-diagonal low-rank matrix assembly
+
+    U12,V12 = H12.U,H12.V
+    U21,V21 = H21.U,H21.V
+
+    # Partition the right-hand side
+
+    (f1,f2) = (f[1:size(H11,1),:],f[1+size(H11,1):end,:])
+
+    # Solve recursively
+
+    A2U21f2,A1U12f1 = woodburysolve(H22,hcat(U21,f2)),woodburysolve(H11,hcat(U12,f1))
+
+    # Compute pivots
+
+    r1,r2 = rank(H12),rank(H21)
+    A = eye(T,r1+r2)
+    for i=1:r1,j=1:r2
+        A[i,j+r1] = dot(V12[:,i],A2U21f2[:,j])
+        A[j+r2,i] = dot(V21[:,j],A1U12f1[:,i])
+    end
+    b = zeros(T,r1+r2,nf)
+    for i=1:nf
+        for j=1:r1
+            b[j,i] = dot(V12[:,j],A2U21f2[:,end-nf+i])
+        end
+        for j=1:r2
+            b[j+r1,i] = dot(V21[:,j],A1U12f1[:,end-nf+i])
+        end
+    end
+
+    vc = A\b
+    v12,v21 = vc[1:r1,:],vc[r1+1:end,:]
+
+    # Solve again with updated right-hand sides
+
+    RHS1 = f1-U12*v12
+    RHS2 = f2-U21*v21
+    reshape([woodburysolve(H11,RHS1);woodburysolve(H22,RHS2)],size(f))
+end

--- a/src/SingularIntegralEquations.jl
+++ b/src/SingularIntegralEquations.jl
@@ -1,5 +1,5 @@
 module SingularIntegralEquations
-    using Base, ApproxFun
+    using Base, ApproxFun, Compat
 
 export cauchy, cauchyintegral, stieltjes, logkernel,stieltjesintegral
 
@@ -35,6 +35,8 @@ stieltjes(f,z)=-2π*im*cauchy(f,z)
 cauchyintegral(u,z)=im/(2π)*stieltjesintegral(u,z)
 
 
+include("LinearAlgebra/LinearAlgebra.jl")
+
 include("Hilbert.jl")
 include("OffHilbert.jl")
 
@@ -48,7 +50,7 @@ include("singfuncauchy.jl")
 
 include("vectorcauchy.jl")
 
-include("./GreensFun/GreensFun.jl")
+include("GreensFun/GreensFun.jl")
 
 include("periodicline.jl")
 include("arc.jl")

--- a/src/SingularIntegralEquations.jl
+++ b/src/SingularIntegralEquations.jl
@@ -13,7 +13,7 @@ import ApproxFun: bandinds,CurveSpace,SpaceOperator,
                   BandedMatrix,bazeros,ChebyshevDirichlet,PolynomialSpace,AbstractProductSpace,evaluate,order,
                   RealBasis,ComplexBasis,AnyBasis,UnsetSpace,ReImSpace,ReImOperator,BivariateFun,linesum,complexlength,
                   ProductFun, LowRankFun, mappoint, PeriodicLineSpace, PeriodicLineDirichlet,Recurrence, CompactFunctional,
-                  real, UnivariateSpace, setdomain
+                  real, UnivariateSpace, setdomain, eps
 
 function cauchy(s,f,z)
     if isa(s,Bool)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using ApproxFun, SingularIntegralEquations, Base.Test
 
 
-if !isdir(Pkg.dir("FastGaussQuadrature")) 
+if !isdir(Pkg.dir("FastGaussQuadrature"))
     warn("Install FastGaussQuadrature.jl for full support.  Some tests not performed")
 end
 
@@ -115,7 +115,7 @@ f2=Fun(sech,PeriodicLine())
 @test_approx_eq cauchy(f2,1.+im) (0.23294739894134472 + 0.10998776661109881im )
 @test_approx_eq cauchy(f2,1.-im) (-0.23294739894134472 + 0.10998776661109881im )
 
-if isdir(Pkg.dir("FastGaussQuadrature")) 
+if isdir(Pkg.dir("FastGaussQuadrature"))
     f=Fun(sech,Line())
     @test_approx_eq cauchy(f,1.+im) cauchy(f2,1.+im)
 end
@@ -149,21 +149,21 @@ d2=Circle(c2,r2)
 
 # complex contour
 
-if isdir(Pkg.dir("FastGaussQuadrature")) 
+if isdir(Pkg.dir("FastGaussQuadrature"))
     #Legendre uses FastGuassQuadrature
     f=Fun(exp,Legendre())
     @test_approx_eq cauchy(f,.1+0.000000000001im) cauchy(+1,f,.1)
     @test_approx_eq cauchy(f,.1-0.000000000001im) cauchy(-1,f,.1)
     @test_approx_eq (cauchy(+1,f,.1)-cauchy(-1,f,.1)) exp(.1)
-    
+
     ω=2.
     d=Interval(0.5im,30.im/ω)
     x=Fun(identity,Legendre(d))
     @test_approx_eq cauchy(exp(im*ω*x),1.+im) (-0.025430235512791915911 + 0.0016246822285867573678im)
-    
-    
+
+
     println("Arc test")
-    
+
     a=Arc(0.,1.,0.,π/2)
     ζ=Fun(identity,a)
     f=Fun(exp,a)*sqrt(abs((ζ-1)*(ζ-im)))
@@ -267,10 +267,14 @@ H=Hilbert(S,0)
 f=real(ζ+1/(ζ-0.1))
 z=0.2+3im;@test_approx_eq (H*f)[z] logkernel(f,z)
 
-if isdir(Pkg.dir("FastGaussQuadrature")) 
+if isdir(Pkg.dir("FastGaussQuadrature"))
     println("Stieltjes moment test")
-    include("stieltjesmomenttest.jl")
+    include("stieltjesmomentTest.jl")
 end
+
+println("Woodbury solve test")
+
+include("woodburysolveTest.jl")
 
 println("Convolution ProductFun test")
 

--- a/test/woodburysolveTest.jl
+++ b/test/woodburysolveTest.jl
@@ -1,0 +1,26 @@
+#
+# test woodburysolve
+#
+using ApproxFun, SingularIntegralEquations, Base.Test
+
+M = 50
+L = Array(LowRankMatrix{Float64},14)
+[L[i] = LowRankMatrix(0.001rand(4M,2),0.001rand(4M,2)) for i=1:2]
+[L[i] = LowRankMatrix(0.01rand(2M,2),0.01rand(2M,2)) for i=[3:4,9:10]]
+[L[i] = LowRankMatrix(0.1rand(M,2),0.1rand(M,2)) for i=[5:8,11:14]]
+D = Array(Diagonal{Float64},8)
+[D[i] = Diagonal(1./[1:M]) for i=1:8]
+
+H = HierarchicalMatrix(D,L)
+b = rand(size(H,1))
+
+full(H)\b
+@time x = full(H)\b
+H\b
+@time xw = H\b
+
+CH = cond(full(H))
+
+@test norm(x-xw) ≤ 10CH^2*eps()
+@test norm(H*x-b) ≤ 10CH*eps()
+@test norm(H*xw-b) ≤ 10CH*eps()


### PR DESCRIPTION
This adds two new matrix types: LowRankMatrix and HierarchicalMatrix.

The LowRankMatrix stores its data in two matrices U (m x r) and V (n x r) such that L = U V^T.

The HierarchicalMatrix has a special constructor for taking two vectors, one for the “diagonal data”, the other for the “off-diagonal data.”

A HierarchicalMatrix with off-diagonal data of the type LowRankMatrix has a special solver, called woodburysolve, that essentially performs recursive block Gaussian elimination. In general it is unstable but fast, and scales favourably with the number of levels in the hierarchy.

Tests for the woodburysolve for matrices simulating the Laplace equation, i.e. diagonal blocks are diagonal matrices from the log transform, on 8 disjoint domains indicate it is significantly faster than a naïve solve.