### PR TITLE
Feat directednumbers

### DIFF
--- a/examples/Ideal Fluid Flow.jl
+++ b/examples/Ideal Fluid Flow.jl
@@ -1,4 +1,4 @@
-using Plots,ApproxFun,SingularIntegralEquations;  gr()
+using Plots,ApproxFun,SingularIntegralEquations;  pyplot()
 
 ##
 #  Ideal fluid flow consists of level sets of the imagainary part of a function
@@ -17,16 +17,32 @@ using Plots,ApproxFun,SingularIntegralEquations;  gr()
 m=80;x = linspace(-2.,2.,m);y = linspace(-1.,1.,m+1)
     xx,yy = x.+0.*y',0.*x.+y'
 
+<<<<<<< HEAD
+=======
+
+d=Circle()
+z=Fun(d)
+f=exp(real(z))
+f(exp(im*0.1))
+
+>>>>>>> 2297bc251a8a2f9f01355295f61b9fcb7ba10547
 k=50
     Γ=Interval(0.,1+0.5im)
     z=Fun(Γ)
     α=exp(-π*k/50im)
+<<<<<<< HEAD
     S=JacobiWeight(0.5,0.5,Γ)
     c,ui=[1 Hilbert(S)]\imag(α*z)
 
 u =(x,y)->α*(x+im*y)+2cauchy(ui,x+im*y)
 plot(Γ)
     contour!(x,y,imag(u(xx,yy))';nlevels=50)
+=======
+    S=JacobiWeight(0.5,0.5,Ultraspherical(1,Γ))
+    c,ui=[1 Hilbert(S)]\imag(α*z)
+plot(Γ)
+    contour!(x,y,imag(u(xx,yy))';nlevels=100,legend=false)
+>>>>>>> 2297bc251a8a2f9f01355295f61b9fcb7ba10547
 
 
 ##
@@ -37,6 +53,11 @@ plot(Γ)
 ##
 
 
+<<<<<<< HEAD
+=======
+u=(x,y)->α*(x+im*y)+2pseudocauchy(ui,x+im*y)
+
+>>>>>>> 2297bc251a8a2f9f01355295f61b9fcb7ba10547
 m=80;x = linspace(-2.,2.,m);y = linspace(-2.,2.,m+1)
     xx,yy = x.+0.*y',0.*x.+y'
 
@@ -44,6 +65,7 @@ k=227;
     Γ=0.5+exp(im*Interval(0.1,-42))
     z=Fun(Γ)
     α=exp(-k/50im)
+<<<<<<< HEAD
     S=JacobiWeight(0.5,0.5,Γ)
     c,ui=[1 PseudoHilbert(S)]\imag(α*z)
 
@@ -54,13 +76,19 @@ plot(Γ)
 
 
 
+=======
+    S=JacobiWeight(0.5,0.5,Ultraspherical(1,Γ))
+    c,ui=[1 PseudoHilbert(S)]\imag(α*z)
+    plot(Γ)
+    contour!(x,y,imag(u(xx,yy))';nlevels=100,legend=false)
+>>>>>>> 2297bc251a8a2f9f01355295f61b9fcb7ba10547
 
 ##
 #  Circle
 ##
 
 Γ=Circle()
-z=Fun(Fourier(Γ))
+z=Fun(Laurent(Γ))
 
 
 u=(x,y)->α*(x+im*y)+2cauchy(ui,x+im*y)
@@ -78,6 +106,10 @@ plot(Γ)
 
 
 
+25
+
+DefiniteLineIntegral(space(z))[1]
+typeof(space(z))==Laurent{typeof(Γ)}
 ##
 # On a curve, the Hilbert transform may be complex, so we
 # take the real part
@@ -108,12 +140,43 @@ z=Fun(Γ)
 S=PiecewiseSpace(map(d->JacobiWeight(0.5,0.5,Ultraspherical(1,d)),Γ))
 
 
+<<<<<<< HEAD
+=======
+u= (x,y) -> α*(x+im*y)+2cauchy(ui,x+im*y)
+
+>>>>>>> 2297bc251a8a2f9f01355295f61b9fcb7ba10547
 m=80;x = linspace(-2.,2.,m);y = linspace(-1.,1.,m+1)
     xx,yy = x.+0.*y',0.*x.+y'
 
 k=114;
     α=exp(k/50*im)
+<<<<<<< HEAD
     a,b,ui=[ones(Γ[1])+zeros(Γ[2]) zeros(Γ[1])+ones(Γ[2]) Hilbert(S)]\imag(α*z)
+=======
+    a,b,ui=[ones(Γ[1])+zeros(Γ[2]) zeros(Γ[1])+ones(Γ[2]) Hilbert(ds)]\imag(α*z)
+    plot(Γ)
+    contour!(x,y,imag(u(xx,yy)))
+
+
+import ApproxFun:colstop,interlace,bandwidth
+
+Ai=interlace([ones(Γ[1])+zeros(Γ[2]) zeros(Γ[1])+ones(Γ[2]) Hilbert(ds)])
+Ai[1:100,1:100]
+
+
+@which colstop(Ai,1)
+
+bandwidth(Ai,1)
+Ai.bandinds
+
+colstop(Ai.ops[3],1)
+
+ApproxFun.isbanded
+ApproxFun.isbanded(ApproxFun.interlace([ones(Γ[1])+zeros(Γ[2]) zeros(Γ[1])+ones(Γ[2]) Hilbert(ds)]))
+
+rangespace(Hilbert(ds))
+
+>>>>>>> 2297bc251a8a2f9f01355295f61b9fcb7ba10547
 
 u=(x,y)->α*(x+im*y)+2cauchy(ui,x+im*y)
 plot(Γ)

--- a/src/HypergeometricFunctions/Gauss.jl
+++ b/src/HypergeometricFunctions/Gauss.jl
@@ -69,11 +69,11 @@ function _₂F₁general(a::Number,b::Number,c::Number,z::Number)
     elseif abs(inv(z)) ≤ ρ
         _₂F₁Inf(a,b,c,z)
     elseif abs(1-inv(z)) ≤ ρ
-        exp(-a*log1p(-z))*_₂F₁Inf(a,c-b,c,z/(z-1))
+        exp(-a*log1p(-z))*_₂F₁Inf(a,c-b,c,reverseorientation(z/(z-1)))
     elseif abs(1-z) ≤ ρ
         _₂F₁one(a,b,c,z)
     elseif abs(inv(1-z)) ≤ ρ
-        exp(-a*log1p(-z))*_₂F₁one(a,c-b,c,z/(z-1))
+        exp(-a*log1p(-z))*_₂F₁one(a,c-b,c,reverseorientation(z/(z-1)))
     else
         _₂F₁taylor(a,b,c,value(z))
     end

--- a/src/HypergeometricFunctions/Gauss.jl
+++ b/src/HypergeometricFunctions/Gauss.jl
@@ -95,7 +95,7 @@ function _₂F₁(a::Number,b::Number,c::Number,z::Number,s::Bool)
     _₂F₁general(a,b,c,z,s) # catch-all
 end
 
-_₂F₁(a::Number,b::Number,c::Number,z::AbstractArray,s...) = reshape(promote_type(typeof(a),typeof(b),typeof(c),eltype(z))[ _₂F₁(a,b,c,z[i],s...) for i in eachindex(z) ], size(z))
+_₂F₁(a::Number,b::Number,c::Number,z::AbstractArray) = reshape(promote_type(typeof(a),typeof(b),typeof(c),eltype(z))[ _₂F₁(a,b,c,z[i]) for i in eachindex(z) ], size(z))
 
 """
 Compute the Gauss hypergeometric function `₂F₁(a,b;c;z)` with general parameters a,b, and c.

--- a/src/HypergeometricFunctions/Gauss.jl
+++ b/src/HypergeometricFunctions/Gauss.jl
@@ -35,7 +35,7 @@ function _₂F₁(a::Number,b::Number,c::Number,z::Number)
         end
     elseif isequal(c,2)
         if abeqcd(a,b,1) # 6. 15.4.1
-            return (s = -z; log1p(s)/s)
+            return (s = -z; log1p(s)/value(s))
         elseif a ∈ ℤ && b == 1 # 5.
             return expm1nlog1p(1-a,-z)
         elseif a == 1 && b ∈ ℤ # 5.
@@ -57,27 +57,25 @@ This polyalgorithm is designed based on the paper
     N. Michel and M. V. Stoitsov, Fast computation of the Gauss hypergeometric function with all its parameters complex with application to the Pöschl–Teller–Ginocchio potential wave functions, Comp. Phys. Commun., 178:535–551, 2008.
 """
 function _₂F₁general(a::Number,b::Number,c::Number,z::Number)
-    T = promote_type(typeof(a),typeof(b),typeof(c),typeof(z))
+    T = promote_type(typeof(a),typeof(b),typeof(c),typeof(value(z)))
 
     real(b) < real(a) && (return _₂F₁general(b,a,c,z))
     real(c) < real(a)+real(b) && (return exp((c-a-b)*log1p(-z))*_₂F₁general(c-a,c-b,c,z))
 
     if abs(z) ≤ ρ || -a ∈ ℕ₀ || -b ∈ ℕ₀
-        _₂F₁maclaurin(a,b,c,z)
-    elseif abs(z/(z-1)) ≤ ρ && absarg(1-z) < convert(real(T),π)
-        exp(-a*log1p(-z))_₂F₁maclaurin(a,c-b,c,z/(z-1))
-    elseif abs(inv(z)) ≤ ρ && absarg(-z) < convert(real(T),π)
+        _₂F₁maclaurin(a,b,c,value(z))
+    elseif abs(z/(z-1)) ≤ ρ
+        exp(-a*log1p(-z))_₂F₁maclaurin(a,c-b,c,value(z/(z-1)))
+    elseif abs(inv(z)) ≤ ρ
         _₂F₁Inf(a,b,c,z)
-    elseif abs(1-inv(z)) ≤ ρ && absarg(z) < convert(real(T),π) && absarg(1-z) < convert(real(T),π)
+    elseif abs(1-inv(z)) ≤ ρ
         exp(-a*log1p(-z))*_₂F₁Inf(a,c-b,c,z/(z-1))
-    elseif abs(1-z) ≤ ρ && absarg(z) < convert(real(T),π) && absarg(1-z) < convert(real(T),π)
+    elseif abs(1-z) ≤ ρ
         _₂F₁one(a,b,c,z)
-    elseif abs(inv(1-z)) ≤ ρ && absarg(-z) < convert(real(T),π)
+    elseif abs(inv(1-z)) ≤ ρ
         exp(-a*log1p(-z))*_₂F₁one(a,c-b,c,z/(z-1))
-    elseif absarg(1-z) < convert(real(T),π)
-        _₂F₁taylor(a,b,c,z)
     else
-        zero(T)#throw(DomainError())
+        _₂F₁taylor(a,b,c,value(z))
     end
 end
 

--- a/src/HypergeometricFunctions/HypergeometricFunctions.jl
+++ b/src/HypergeometricFunctions/HypergeometricFunctions.jl
@@ -6,7 +6,7 @@ This module calculates (generalized) hypergeometric functions:
 module HypergeometricFunctions
 
 using DualNumbers
-import ApproxFun: @clenshaw, real, eps
+import ApproxFun: @clenshaw, real, eps, reverseorientation
 import FastTransforms: pochhammer
 
 export _₂F₁, _₃F₂, mFn

--- a/src/HypergeometricFunctions/specialfunctions.jl
+++ b/src/HypergeometricFunctions/specialfunctions.jl
@@ -235,7 +235,7 @@ function _₂F₁one(a,b,c,z)
     m = round(Int,real(c-(a+b)))
     ϵ = c-(a+b)-m
     w = 1-z
-    (-1)^m/sinc(ϵ)*(Aone(a,b,c,w,m,ϵ) + Bone(a,b,c,w,m,ϵ))
+    (-1)^m/sinc(ϵ)*(Aone(a,b,c,value(w),m,ϵ) + Bone(a,b,c,w,m,ϵ))
 end
 
 # Transformation formula w = 1/z
@@ -259,8 +259,9 @@ function AInf(a,b,c,w,m::Int,ϵ)
     ret
 end
 
-function BInf(a,b,c,w,m::Int,ϵ)
-    βₙ,γₙ = recInfβ₀(a,b,c,w,m,ϵ)*one(w),recInfγ₀(a,b,c,w,m,ϵ)*w
+function BInf(a,b,c,win,m::Int,ϵ)
+    w=value(win)
+    βₙ,γₙ = recInfβ₀(a,b,c,win,m,ϵ)*one(w),recInfγ₀(a,b,c,win,m,ϵ)*w
     ret,err,n = βₙ,1.0,0
     while err > 10eps()
         βₙ = (a+m+n+ϵ)*(1-c+a+m+n+ϵ)/((m+n+1+ϵ)*(n+1))*w*βₙ + ( (a+m+n)*(1-c+a+m+n)/(m+n+1) - (a+m+n) - (1-c+a+m+n) - ϵ + (a+m+n+ϵ)*(1-c+a+m+n+ϵ)/(n+1) )*γₙ/((m+n+1+ϵ)*(n+1-ϵ))
@@ -275,8 +276,8 @@ end
 function _₂F₁Inf(a,b,c,z)
     m = round(Int,real(b-a))
     ϵ = b-a-m
-    w = inv(z)
-    (-1)^m*(-w)^a/sinc(ϵ)*(AInf(a,b,c,w,m,ϵ) + BInf(a,b,c,w,m,ϵ))
+    w = reverseorientation(inv(z))  # we've swapped the branch cut
+    (-1)^m*(-w)^a/sinc(ϵ)*(AInf(a,b,c,value(w),m,ϵ) + BInf(a,b,c,w,m,ϵ))
 end
 
 

--- a/src/HypergeometricFunctions/specialfunctions.jl
+++ b/src/HypergeometricFunctions/specialfunctions.jl
@@ -265,8 +265,8 @@ function AInf(a,b,c,w,m::Int,ϵ)
     ret
 end
 
-function BInf(a,b,c,w,m::Int,ϵ,s...)
-    βₙ,γₙ = recInfβ₀(a,b,c,w,m,ϵ,s...)*one(w),recInfγ₀(a,b,c,w,m,ϵ)*w
+function BInf(a,b,c,w,m::Int,ϵ)
+    βₙ,γₙ = recInfβ₀(a,b,c,w,m,ϵ)*one(w),recInfγ₀(a,b,c,w,m,ϵ)*w
     ret,err,n = βₙ,1.0,0
     while err > 10eps()
         βₙ = (a+m+n+ϵ)*(1-c+a+m+n+ϵ)/((m+n+1+ϵ)*(n+1))*w*βₙ + ( (a+m+n)*(1-c+a+m+n)/(m+n+1) - (a+m+n) - (1-c+a+m+n) - ϵ + (a+m+n+ϵ)*(1-c+a+m+n+ϵ)/(n+1) )*γₙ/((m+n+1+ϵ)*(n+1-ϵ))

--- a/src/HypergeometricFunctions/specialfunctions.jl
+++ b/src/HypergeometricFunctions/specialfunctions.jl
@@ -247,12 +247,6 @@ recInfβ₀(a,b,c,w,m::Int,ϵ) = abs(ϵ) > 0.1 ?
                         ( (pochhammer(float(1-c+a)+ϵ,m)*G(1.0,-ϵ)-P(1-c+a,ϵ,m)/gamma(1-ϵ))/(gamma(c-a)*gamma(a+m+ϵ)*gamma(m+1)) +
                                 pochhammer(float(1-c+a)+ϵ,m)*( (G(m+1.0,ϵ)/gamma(a+m+ϵ) - G(float(a)+m,ϵ)/gamma(m+1+ϵ))/gamma(c-a) -
                                     (G(float(c-a),-ϵ) - E(-log(-w),-ϵ)/gamma(c-a-ϵ))/(gamma(m+1+ϵ)*gamma(a+m)) ) )*gamma(c)*pochhammer(float(a),m)*w^m
-recInfβ₀(a,b,c,w,m::Int,ϵ,s::Bool) = abs(ϵ) > 0.1 ?
-                        ( pochhammer(float(a),m)*pochhammer(float(1-c+a),m)/(gamma(1-ϵ)*gamma(a+m+ϵ)*gamma(c-a)*gamma(m+1)) -
-                                exp((s?-1:1)*π*im*ϵ)*w^ϵ*pochhammer(float(1-c+a)+ϵ,m)/(gamma(a)*gamma(c-a-ϵ)*gamma(m+1+ϵ)) )*gamma(c)*w^m/ϵ :
-                        ( (pochhammer(float(1-c+a)+ϵ,m)*G(1.0,-ϵ)-P(1-c+a,ϵ,m)/gamma(1-ϵ))/(gamma(c-a)*gamma(a+m+ϵ)*gamma(m+1)) +
-                                pochhammer(float(1-c+a)+ϵ,m)*( (G(m+1.0,ϵ)/gamma(a+m+ϵ) - G(float(a)+m,ϵ)/gamma(m+1+ϵ))/gamma(c-a) -
-                                    (G(float(c-a),-ϵ) - E(-(log(w)+(s?-1:1)*π*im),-ϵ)/gamma(c-a-ϵ))/(gamma(m+1+ϵ)*gamma(a+m)) ) )*gamma(c)*pochhammer(float(a),m)*w^m
 recInfγ₀(a,b,c,w,m::Int,ϵ) = gamma(c)*pochhammer(float(a),m)*pochhammer(float(1-c+a),m)*w^m/(gamma(a+m+ϵ)*gamma(c-a)*gamma(m+1)*gamma(1-ϵ))
 
 function AInf(a,b,c,w,m::Int,ϵ)
@@ -285,12 +279,6 @@ function _₂F₁Inf(a,b,c,z)
     (-1)^m*(-w)^a/sinc(ϵ)*(AInf(a,b,c,w,m,ϵ) + BInf(a,b,c,w,m,ϵ))
 end
 
-function _₂F₁Inf(a,b,c,z,s::Bool)
-    m = round(Int,real(b-a))
-    ϵ = b-a-m
-    w = inv(z)
-    (-1)^m*exp((s?-1:1)*a*π*im)*w^a/sinc(ϵ)*(AInf(a,b,c,w,m,ϵ) + BInf(a,b,c,w,m,ϵ,s))
-end
 
 function _₂F₁maclaurin(a::Number,b::Number,c::Number,z::Number)
     T = promote_type(typeof(a),typeof(b),typeof(c),typeof(z))

--- a/src/Operators/OffHilbert.jl
+++ b/src/Operators/OffHilbert.jl
@@ -89,7 +89,7 @@ for (Op,Len) in ((:OffHilbert,:complexlength),(:OffSingularIntegral,:arclength))
             if ord == 0
                 z=Fun(identity,rs)
                 x=mobius(ds,z)
-                y=intervaloffcircle(true,x)
+                y=joukowskyinverse(Val{true},x)
                 yk,ykp1=y,y*y
                 ret=Array(typeof(y),300)
                 ret[1]=-.5logabs(2y)+.25real(ykp1)
@@ -104,7 +104,7 @@ for (Op,Len) in ((:OffHilbert,:complexlength),(:OffSingularIntegral,:arclength))
                     l=max(l,ncoefficients(ret[n])-n)
                 end
             elseif ord == 1
-                y=Fun(z->intervaloffcircle(true,mobius(ds,z)),rs)
+                y=Fun(z->joukowskyinverse(Val{true},mobius(ds,z)),rs)
                 ret=Array(typeof(y),300)
                 ret[1]=-y
                 n,l,u = 1,ncoefficients(ret[1])-1,0
@@ -134,7 +134,7 @@ for (Op,Len) in ((:OffHilbert,:complexlength),(:OffSingularIntegral,:arclength))
             if ord == 0
                 z=Fun(identity,rs)
                 x=mobius(ds,z)
-                y=intervaloffcircle(true,x)
+                y=joukowskyinverse(Val{true},x)
                 yk,ykp1=y,y*y
                 ret=Array(typeof(y),300)
                 ret[1]=-logabs(2y/C)
@@ -153,7 +153,7 @@ for (Op,Len) in ((:OffHilbert,:complexlength),(:OffSingularIntegral,:arclength))
             elseif ord == 1
                 z=Fun(identity,rs)
                 x=mobius(ds,z)
-                y=intervaloffcircle(true,x)
+                y=joukowskyinverse(Val{true},x)
                 ret=Array(typeof(y),300)
                 ret[1]=-1/sqrtx2(x)
                 ret[2]=x*ret[1]+1
@@ -400,9 +400,9 @@ function OffHilbert{DD}(sp::JacobiWeight{Ultraspherical{Int,DD},DD},z::Number)
     @assert order(sp.space) == 1
     if sp.α == sp.β == 0.5
         # this translates the following cauchy to a functional
-        #    0.5im*hornersum(cfs,intervaloffcircle(true,mobius(u,z)))
+        #    0.5im*hornersum(cfs,joukowskyinverse(Val{true},mobius(u,z)))
         # which consists of multiplying by 2*im
-        -HornerFunctional(intervaloffcircle(true,mobius(sp,z)),sp)
+        -HornerFunctional(joukowskyinverse(Val{true},mobius(sp,z)),sp)
     else
         # calculate directly
         r=Array(eltype(z),0)

--- a/src/SingularIntegralEquations.jl
+++ b/src/SingularIntegralEquations.jl
@@ -62,6 +62,7 @@ orientation{s}(::Type{Directed{s}}) = s
 orientation{s}(::Directed{s}) = s
 value(x::Directed) = x.x
 value(x::Number) = x
+value(x::Fun) = x
 reverseorientation{s}(x::Directed{s}) = Directed{!s}(x.x)
 reverseorientation(x::Number) = x
 
@@ -75,7 +76,8 @@ for OP in (:*,:+,:-,:/)
     end
 end
 
-for OP in (:(Base.isfinite),:(Base.isinf))
+# abs, real and imag delete orientation.
+for OP in (:(Base.isfinite),:(Base.isinf),:(Base.abs),:(Base.real),:(Base.imag))
     @eval $OP(a::Directed) = $OP(a.x)
 end
 

--- a/src/SingularIntegralEquations.jl
+++ b/src/SingularIntegralEquations.jl
@@ -62,6 +62,8 @@ orientationsign(::Type{Directed{true}}) = 1
 orientationsign(::Type{Directed{false}}) = -1
 orientation{s}(::Type{Directed{s}}) = s
 orientation{s}(::Directed{s}) = s
+
+
 value(x::Directed) = x.x
 value(x::Number) = x
 value(x::Fun) = x

--- a/src/SingularIntegralEquations.jl
+++ b/src/SingularIntegralEquations.jl
@@ -48,19 +48,16 @@ Base.convert{s}(::Type{Directed{s}},x) = Directed{s,eltype(x)}(x)
 const ⁺ = Directed{true}(true)
 const ⁻ = Directed{false}(true)
 
-1⁺
-1⁻
+
+
+
 
 
 # we don't override for Bool and Function to make overriding below easier
 # TODO: change when cauchy(f,z,s) calls cauchy(f.coefficients,space(f),z,s)
 
 for OP in (:stieltjes,:stieltjesintegral,:pseudostieltjes)
-    @eval begin
-        $OP(f::Fun)=$OP(space(f),coefficients(f))
-        $OP(f::Fun,z,s...)=$OP(space(f),coefficients(f),z,s...)
-        $OP(f::Fun,z,s::Function)=$OP(f,z,s==+)
-    end
+    @eval $OP(f::Fun)=$OP(space(f),coefficients(f))
 end
 
 hilbert(f) = Hilbert()*f
@@ -137,8 +134,8 @@ function testsieeval(S::Space)
         f=Fun([zeros(k-1);1],S)
         @test abs(linesum(f*log(abs(x-z)))/π-logkernel(f,z)) ≤ 100eps()
         @test abs(sum(f/(z-x))-stieltjes(f,z)) ≤ 100eps()
-        @test_approx_eq cauchy(f,p,+)-cauchy(f,p,-) f(p)
-        @test_approx_eq im*(cauchy(f,p,+)+cauchy(f,p,-)) hilbert(f,p)
+        @test_approx_eq cauchy(f,p⁺)-cauchy(f,p⁻) f(p)
+        @test_approx_eq im*(cauchy(f,p⁺)+cauchy(f,p⁻)) hilbert(f,p)
     end
 end
 

--- a/src/SingularIntegralEquations.jl
+++ b/src/SingularIntegralEquations.jl
@@ -34,6 +34,8 @@ import ApproxFun: bandinds, blockbandinds, SpaceOperator, bilinearform, linebili
 
 import ApproxFun: testbandedoperator
 
+import DualNumbers: value
+
 """
 `Directed` represents a number that is a limit from either left (s=true) or right (s=false)
 For functions with branch cuts, it is assumed that the value is on the branch cut,
@@ -76,8 +78,10 @@ for OP in (:*,:+,:-,:/)
     end
 end
 
+real{s,T}(::Type{Directed{s,T}}) = real(T)
+
 # abs, real and imag delete orientation.
-for OP in (:(Base.isfinite),:(Base.isinf),:(Base.abs),:(Base.real),:(Base.imag))
+for OP in (:(Base.isfinite),:(Base.isinf),:(Base.abs),:(Base.real),:(Base.imag),:(Base.angle))
     @eval $OP(a::Directed) = $OP(a.x)
 end
 
@@ -88,6 +92,8 @@ Base.log(x::Directed{false}) = log(-x.x) + π*im
 Base.log1p(x::Directed) = log(1+x)
 Base.sqrt(x::Directed{true}) = -im*sqrt(-x.x)
 Base.sqrt(x::Directed{false}) = im*sqrt(-x.x)
+^(x::Directed{true},a::Integer) = x.x^a
+^(x::Directed{false},a::Integer) = x.x^a
 ^(x::Directed{true},a::Number) = exp(-a*π*im)*(-x.x)^a
 ^(x::Directed{false},a::Number) = exp(a*π*im)*(-x.x)^a
 

--- a/src/SingularIntegralEquations.jl
+++ b/src/SingularIntegralEquations.jl
@@ -34,6 +34,24 @@ import ApproxFun: bandinds, blockbandinds, SpaceOperator, bilinearform, linebili
 
 import ApproxFun: testbandedoperator
 
+"""
+`Directed` represents a number that is a limit from either left (s=true) or right (s=false)
+"""
+immutable Directed{s,T}
+    x::T
+end
+
+Base.convert{s}(::Type{Directed{s}},x) = Directed{s,eltype(x)}(x)
+*{s}(a::Directed{s},b::Number) = Directed{s}(a.x*b)
+*{s}(b::Number,a::Directed{s}) = a*b
+
+const ⁺ = Directed{true}(true)
+const ⁻ = Directed{false}(true)
+
+1⁺
+1⁻
+
+
 # we don't override for Bool and Function to make overriding below easier
 # TODO: change when cauchy(f,z,s) calls cauchy(f.coefficients,space(f),z,s)
 

--- a/src/arc.jl
+++ b/src/arc.jl
@@ -3,11 +3,11 @@
 ## Cauchy
 
 # pseudocauchy does not normalize at ∞
-pseudostieltjes{LS,RR<:Arc}(S::Space{LS,RR},f,z,s...) = stieltjes(setcanonicaldomain(S),f,mobius(S,z),s...)
+pseudostieltjes{LS,RR<:Arc}(S::Space{LS,RR},f,z) = stieltjes(setcanonicaldomain(S),f,mobius(S,z))
 pseudohilbert{LS,RR<:Arc}(S::Space{LS,RR},f,z) = hilbert(setdomain(S,Interval()),f,mobius(S,z))
 
 
-stieltjes{LS,RR<:Arc}(S::Space{LS,RR},f,z,s...) = stieltjes(setcanonicaldomain(S),f,mobius(S,z),s...)-stieltjes(setcanonicaldomain(S),f,mobius(S,Inf))
+stieltjes{LS,RR<:Arc}(S::Space{LS,RR},f,z) = stieltjes(setcanonicaldomain(S),f,mobius(S,z))-stieltjes(setcanonicaldomain(S),f,mobius(S,Inf))
 hilbert{LS,RR<:Arc}(S::Space{LS,RR},f,z) = hilbert(setcanonicaldomain(S),f,mobius(S,z))+(1/π)*stieltjes(setcanonicaldomain(S),f,mobius(S,Inf))
 
 

--- a/src/circlecauchy.jl
+++ b/src/circlecauchy.jl
@@ -28,14 +28,6 @@ function cauchycircleS(cfs::AbstractVector,z::Number,s::Bool)
 end
 
 
-function stieltjes{DD<:Circle}(sp::Laurent{DD},f::AbstractVector,z,s::Bool)
-    d=domain(sp)
-    if !d.orientation
-        return -stieltjes(reverseorientation(Fun(f,sp)),z,!s)
-    end
-    @assert in(z,d)
-    -2π*im*cauchycircleS(f,mappoint(d,Circle(),z),s)
-end
 function stieltjes{DD<:Circle}(sp::Laurent{DD},f::AbstractVector,z::Number)
     d=domain(sp)
     if !d.orientation
@@ -46,8 +38,18 @@ function stieltjes{DD<:Circle}(sp::Laurent{DD},f::AbstractVector,z::Number)
     -2π*im*cauchycircleS(f,z,abs(z) < 1)
 end
 
-stieltjes{DD<:Circle}(sp::Laurent{DD},f,z::Vector)=[stieltjes(sp,f,zk) for zk in z]
-stieltjes{DD<:Circle}(sp::Laurent{DD},f,z::Matrix)=reshape(stieltjes(sp,f,vec(z)),size(z,1),size(z,2))
+function stieltjes{DD<:Circle,s}(sp::Laurent{DD},f::AbstractVector,z::Directed{s})
+    d=domain(sp)
+    if !d.orientation
+        return -stieltjes(reverseorientation(Fun(f,sp)),reverseorientation(z))
+    end
+
+    z=mappoint(d,Circle(),z)
+    -2π*im*cauchycircleS(f,z,orientation(z))
+end
+
+stieltjes{DD<:Circle}(sp::Laurent{DD},f,z::Vector) = [stieltjes(sp,f,zk) for zk in z]
+stieltjes{DD<:Circle}(sp::Laurent{DD},f,z::Matrix) = reshape(stieltjes(sp,f,vec(z)),size(z,1),size(z,2))
 
 
 

--- a/src/circlecauchy.jl
+++ b/src/circlecauchy.jl
@@ -45,7 +45,7 @@ function stieltjes{DD<:Circle,s}(sp::Laurent{DD},f::AbstractVector,z::Directed{s
     end
 
     z=mappoint(d,Circle(),z)
-    -2π*im*cauchycircleS(f,z,orientation(z))
+    -2π*im*cauchycircleS(f,value(z),orientation(z))
 end
 
 stieltjes{DD<:Circle}(sp::Laurent{DD},f,z::Vector) = [stieltjes(sp,f,zk) for zk in z]
@@ -54,12 +54,13 @@ stieltjes{DD<:Circle}(sp::Laurent{DD},f,z::Matrix) = reshape(stieltjes(sp,f,vec(
 
 
 
-stieltjes{DD<:Circle}(sp::Fourier{DD},f,z)=stieltjes(Laurent(domain(sp)),coefficients(f,sp,Laurent(domain(sp))),z)
+stieltjes{DD<:Circle}(sp::Fourier{DD},f,z) = stieltjes(Laurent(domain(sp)),coefficients(f,sp,Laurent(domain(sp))),z)
 
 
 
 # we implement cauchy ±1 as canonical
-hilbert{DD<:Circle}(sp::Laurent{DD},f,z)=(stieltjes(sp,f,z,true)+stieltjes(sp,f,z,false))/(-2π)
+# TODO: reimplement directly
+hilbert{DD<:Circle}(sp::Laurent{DD},f,z) = (stieltjes(sp,f,z*⁺)+stieltjes(sp,f,z*⁻))/(-2π)
 
 
 

--- a/src/circlecauchy.jl
+++ b/src/circlecauchy.jl
@@ -52,7 +52,7 @@ stieltjes{DD<:Circle}(sp::Laurent{DD},f,z::Matrix)=reshape(stieltjes(sp,f,vec(z)
 
 
 
-stieltjes{DD<:Circle}(sp::Fourier{DD},f,z,s...)=stieltjes(Laurent(domain(sp)),coefficients(f,sp,Laurent(domain(sp))),z,s...)
+stieltjes{DD<:Circle}(sp::Fourier{DD},f,z)=stieltjes(Laurent(domain(sp)),coefficients(f,sp,Laurent(domain(sp))),z)
 
 
 
@@ -67,16 +67,16 @@ hilbert{DD<:Circle}(sp::Laurent{DD},f,z)=(stieltjes(sp,f,z,true)+stieltjes(sp,f,
 ## stieltjesintegral and logkernel
 
 
-function stieltjesintegral{DD<:Circle}(sp::Laurent{DD},f,z::Number,s...)
+function stieltjesintegral{DD<:Circle}(sp::Laurent{DD},f,z::Number)
     d=domain(sp)
     @assert d==Circle()  #TODO: radius
     ζ=Fun(d)
-    r=stieltjes(integrate(f-f[2]/ζ),z,s...)
+    r=stieltjes(integrate(f-f[2]/ζ),z)
     abs(z)<1?r:r+2π*im*f[2]*log(z)
 end
 
 
-stieltjesintegral{DD<:Circle}(sp::Fourier{DD},f,z::Number,s...)=stieltjesintegral(Fun(Fun(f,sp),Laurent),z,s...)
+stieltjesintegral{DD<:Circle}(sp::Fourier{DD},f,z::Number)=stieltjesintegral(Fun(Fun(f,sp),Laurent),z)
 
 function logkernel{DD<:Circle}(sp::Fourier{DD},g,z::Number)
     d=domain(sp)

--- a/src/curve.jl
+++ b/src/curve.jl
@@ -3,11 +3,11 @@
 stieltjes{C<:Curve,SS}(S::Space{SS,C},f,z::Number) =
     sum(stieltjes(setcanonicaldomain(S),f,complexroots(domain(S).curve-z)))
 
-function stieltjes{C<:Curve,SS}(S::Space{SS,C},f,z::Number,s::Bool)
+function stieltjes{s,C<:Curve,SS}(S::Space{SS,C},f,z::Directed{s})
     #project
-    rts=complexroots(domain(S).curve-z)
+    rts=complexroots(domain(S).curve-z.x)
     di=domain(S.space)
-    mapreduce(rt->in(rt,di)?stieltjes(S.space,f,rt,s):stieltjes(S.space,f,rt),+,rts)
+    mapreduce(rt->in(rt,di)?stieltjes(S.space,f,Directed{s}(rt)):stieltjes(S.space,f,rt),+,rts)
 end
 
 stieltjes{C<:Curve,SS}(S::Space{SS,C},f,z::Vector) =
@@ -71,16 +71,16 @@ function stieltjes{C<:PeriodicCurve}(S::Laurent{C},f,z::Number)
             div(ncoefficients(domain(S).curve),2)*stieltjes(setdomain(S,Circle()),f,0.)
 end
 
-function stieltjes{C<:PeriodicCurve}(S::Laurent{C},f,z::Number,s::Bool)
+function stieltjes{s,C<:PeriodicCurve}(S::Laurent{C},f,z::Directed{s})
     c=domain(S)  # the curve that f lives on
     @assert domain(c.curve)==Circle()
-    rts=complexroots(c.curve-z)
+    rts=complexroots(c.curve-z.x)
 
     csp=setdomain(S,Circle())
     ret=-div(ncoefficients(domain(S).curve),2)*stieltjes(csp,f,0.)
 
     for k=2:length(rts)
-        ret+=in(rts[k],Circle())?stieltjes(csp,f,rts[k]):stieltjes(csp,f,rts[k],s)
+        ret+=in(rts[k],Circle())?stieltjes(csp,f,Directed{s}(rts[k])):stieltjes(csp,f,rts[k])
     end
     ret
 end

--- a/src/intervalcauchy.jl
+++ b/src/intervalcauchy.jl
@@ -53,12 +53,6 @@ function stieltjes{D<:Interval}(S::PolynomialSpace{D},f,z::Number)
     end
 end
 
-function stieltjes{D<:Interval}(S::PolynomialSpace{D},f,z::Number,s::Bool)
-    @assert domain(S)==Interval()
-
-    cfs=stieltjesforward(Legendre(),length(f),z,s)
-    dotu(cfs,coefficients(f,S,Legendre()))
-end
 
 
 

--- a/src/intervalcauchy.jl
+++ b/src/intervalcauchy.jl
@@ -24,9 +24,9 @@ end
 forwardsubstitution(R,n,μ1,μ2) =
     forwardsubstitution!(Array(promote_type(eltype(R),typeof(μ1),typeof(μ2)),n),R,n,μ1,μ2)
 
-stieltjesforward(sp::Space,n,z,s...) = forwardsubstitution(JacobiZ(sp,z),n,
-                                                            stieltjesmoment(sp,0,z,s...),
-                                                            stieltjesmoment(sp,1,z,s...))
+stieltjesforward(sp::Space,n,z) = forwardsubstitution(JacobiZ(sp,z),n,
+                                                            stieltjesmoment(sp,0,z),
+                                                            stieltjesmoment(sp,1,z))
 
 
 
@@ -63,13 +63,13 @@ end
 
 
 # Sum over all inverses of fromcanonical, see [Olver,2014]
-function stieltjes{SS,L<:Line}(S::Space{SS,L},f,z,s...)
+function stieltjes{SS,L<:Line}(S::Space{SS,L},f,z)
     if domain(S)==Line()
         # TODO: rename tocanonical
-        stieltjes(setcanonicaldomain(S),f,tocanonical(S,z),s...) +
+        stieltjes(setcanonicaldomain(S),f,tocanonical(S,z)) +
             stieltjes(setcanonicaldomain(S),f,(-1-sqrt(1+4z.^2))./(2z))
     else
-        stieltjes(setdomain(S,Line()),f,mappoint(domain(S),Line(),z),s...)
+        stieltjes(setdomain(S,Line()),f,mappoint(domain(S),Line(),z))
     end
 end
 

--- a/src/periodicline.jl
+++ b/src/periodicline.jl
@@ -3,9 +3,9 @@
 ## stieltjes
 
 
-function stieltjes{L<:PeriodicLine,SS}(S::Space{SS,L},f,z::Number,s...)
+function stieltjes{L<:PeriodicLine,SS}(S::Space{SS,L},f,z::Number)
     S2=setdomain(S,Circle())
-    stieltjes(S2,f,mappoint(domain(S),Circle(),z),s...)+hilbert(S2,f,-1)*π
+    stieltjes(S2,f,mappoint(domain(S),Circle(),z))+hilbert(S2,f,-1)*π
 end
 
 

--- a/src/singfuncauchy.jl
+++ b/src/singfuncauchy.jl
@@ -59,10 +59,10 @@ realdivkhornersum{S<:Real}(cfs::AbstractVector{S},y,ys,s) = real(divkhornersum(c
 realdivkhornersum{S<:Complex}(cfs::AbstractVector{S},y,ys,s) = complex(real(divkhornersum(real(cfs),y,ys,s)),real(divkhornersum(imag(cfs),y,ys,s)))
 
 
-function stieltjes{S<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{S,DD},u,zv::Array,s...)
+function stieltjes{S<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{S,DD},u,zv::Array)
     ret=similar(zv,Complex128)
     for k=1:length(zv)
-        @inbounds ret[k]=stieltjes(sp,u,zv[k],s...)
+        @inbounds ret[k]=stieltjes(sp,u,zv[k])
     end
     ret
 end

--- a/src/singfuncauchy.jl
+++ b/src/singfuncauchy.jl
@@ -235,7 +235,7 @@ function stieltjesintegral{S<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{S,D
             ret = -cfs[1]*π*complexlength(d)*(log(y)+log(4/abs(b-a)))/2
 
             if length(cfs) ≥2
-                ret += -π*complexlength(d)*cfs[2]*jouksyinverse(Val{true},z)/2
+                ret += -π*complexlength(d)*cfs[2]*joukowskyinverse(Val{true},z)/2
             end
 
             if length(cfs) ≥3

--- a/src/singfuncauchy.jl
+++ b/src/singfuncauchy.jl
@@ -13,21 +13,13 @@ function sqrtx2(f::Fun)
     linsolve([B,A],[sqrtx2(first(f))];tolerance=ncoefficients(f)*10E-15)
 end
 
-# intervaloffcircle maps the slit plane to the interior(true)/exterior(false) disk
-# intervaloncircle maps the interval to the upper(true)/lower(false) half circle
+# these are two inverses of the joukowsky map
+# the first maps the slit plane to the inner circle, the second to the outer circle
+#
+# it is more accurate near infinity to do 1/J_- than z - sqrtx2(z) as it avoids round off
+joukowskyinverse(::Type{Val{true}},z) = 1./joukowskyinverse(Val{false},reverseorientation(z))
+joukowskyinverse(::Type{Val{false}},z) = z+sqrtx2(z)
 
-# it is more accurate near infinity to do 1/J_- as it avoids round off
-intervaloffcircle(s::Bool,z)=s?1./intervaloffcircle(false,z):(z+sqrtx2(z))
-intervaloncircle(s::Bool,x)=x+1.0im*(s?1:-1).*sqrt(1-x).*sqrt(x+1)
-
-intervaloffcircle(s::Int,x)=intervaloffcircle(s==1,x)
-intervaloncircle(s::Int,x)=intervaloncircle(s==1,x)
-
-#TODO: These aren't quite typed correctly but the trouble comes from anticipating the unifying type without checking every element.
-
-updownjoukowskyinverse{T<:Number}(s::Bool,x::T) = in(x,Interval(-one(T),one(T))) ? intervaloncircle(s,x) : intervaloffcircle(s,x)
-updownjoukowskyinverse{T<:Number}(s::Bool,x::Vector{T}) = Complex{real(T)}[updownjoukowskyinverse(s,xk) for xk in x]
-updownjoukowskyinverse{T<:Number}(s::Bool,x::Array{T,2}) = Complex{real(T)}[updownjoukowskyinverse(s,x[k,j]) for k=1:size(x,1),j=1:size(x,2)]
 
 function hornersum{S<:Number,V<:Number}(cfs::AbstractVector{S},y::V)
     N,P = length(cfs),promote_type(S,V)
@@ -107,41 +99,6 @@ function stieltjes{S<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{S,DD},u,z)
 end
 
 
-function stieltjes{SS<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{SS,DD},u,x::Number,s::Bool)
-    d=domain(sp)
-
-    if sp.α == sp.β == .5
-        cfs=coefficients(u,sp.space,Ultraspherical(1,d))
-        π*hornersum(cfs,intervaloncircle(!s,mobius(sp,x)))
-    elseif sp.α == sp.β == -.5
-        cfs = coefficients(u,sp.space,ChebyshevDirichlet{1,1}(d))
-        x=mobius(sp,x)
-
-        if length(cfs) ≥1
-            ret = -π*im*cfs[1]*(s?1:-1)/sqrt(1-x^2)
-
-            if length(cfs) ≥2
-                ret += cfs[2]*(-π*im*(s?1:-1)*x/sqrt(1-x^2)-π)
-            end
-
-            ret - 2π*hornersum(cfs[3:end],intervaloncircle(!s,x))
-        else
-            0.0+0.0im
-        end
-    else
-        if d==Interval()
-            S=JacobiWeight(sp.α,sp.β,Jacobi(sp.β,sp.α))
-            cfs=coefficients(u,sp,S)
-            cf=stieltjesforward(S,length(cfs),x,s)
-            dotu(cf,cfs)
-        else
-            @assert isa(d,Interval)
-            stieltjes(setdomain(sp,Interval()),u,mobius(sp,x),s)
-        end
-    end
-end
-
-
 
 ##
 #  hilbert on JacobiWeight space
@@ -193,12 +150,12 @@ function logkernel{S<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{S,DD},u,z)
     if sp.α == sp.β == .5
         cfs=coefficients(u,sp.space,Ultraspherical(1,d))
         z=mobius(sp,z)
-        y = updownjoukowskyinverse(true,z)
+        y = joukowskyinverse(Val{true},z)
         arclength(d)*realintegratejin(4/(b-a),cfs,y)/2
     elseif  sp.α == sp.β == -.5
         cfs = coefficients(u,sp.space,ChebyshevDirichlet{1,1}(d))
         z=mobius(sp,z)
-        y = updownjoukowskyinverse(true,z)
+        y = joukowskyinverse(Val{true},z)
 
         if length(cfs) ≥1
             ret = -cfs[1]*arclength(d)*(logabs(y)+logabs(4/(b-a)))/2
@@ -234,55 +191,22 @@ function stieltjesintegral{S<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{S,D
 
     if sp.α == sp.β == .5
         cfs=coefficients(u,sp.space,Ultraspherical(1,d))
-        y=intervaloffcircle(true,mobius(sp,z))
+        y=joukowskyinverse(Val{true},mobius(sp,z))
         π*complexlength(d)*integratejin(4/(b-a),cfs,y)/2
     elseif  sp.α == sp.β == -.5
         cfs = coefficients(u,sp.space,ChebyshevDirichlet{1,1}(d))
         z=mobius(sp,z)
-        y=intervaloffcircle(true,z)
+        y=joukowskyinverse(Val{true},z)
 
         if length(cfs) ≥1
             ret = -cfs[1]*π*complexlength(d)*(log(y)+log(4/abs(b-a)))/2
 
             if length(cfs) ≥2
-                ret += -π*complexlength(d)*cfs[2]*intervaloffcircle(true,z)/2
+                ret += -π*complexlength(d)*cfs[2]*jouksyinverse(Val{true},z)/2
             end
 
             if length(cfs) ≥3
                 ret - π*complexlength(d)*integratejin(4/abs(b-a),view(cfs,3:length(cfs)),y)
-            else
-                ret
-            end
-        else
-            zero(z)
-        end
-    else
-        error("stieltjes integral not implemented for parameters "*string(sp.α)*","*string(sp.β))
-    end
-end
-
-function stieltjesintegral{S<:PolynomialSpace,DD<:Interval}(sp::JacobiWeight{S,DD},u,z,s::Bool)
-    d=domain(u)
-    a,b=d.a,d.b     # TODO: type not inferred right now
-
-    if sp.α == sp.β == .5
-        cfs=coefficients(u,sp.space,Ultraspherical(1,d))
-        y=intervaloncircle(!s,mobius(sp,z))
-        π*complexlength(d)*integratejin(4/(b-a),cfs,y)/2
-    elseif  sp.α == sp.β == -.5
-        cfs = coefficients(u,sp.space,ChebyshevDirichlet{1,1}(d))
-        z=mobius(sp,z)
-        y=intervaloncircle(!s,z)
-
-        if length(cfs) ≥1
-            ret = -cfs[1]*π*complexlength(d)*(log(y)+log(4/(b-a)))/2
-
-            if length(cfs) ≥2
-                ret += -π*complexlength(d)*cfs[2]*intervaloncircle(!s,z)/2
-            end
-
-            if length(cfs) ≥3
-                ret - π*complexlength(d)*integratejin(4/(b-a),view(cfs,3:length(cfs)),y)
             else
                 ret
             end

--- a/src/stieltjesmoment.jl
+++ b/src/stieltjesmoment.jl
@@ -43,7 +43,8 @@ logjacobimoment(α::Real,β::Real,z) = logjacobimoment(α,β,0,z)
 stieltjeslegendremoment(n::Int,z) = stieltjesjacobimoment(zero(real(eltype(z))),zero(real(eltype(z))),n,z)
 stieltjeslegendremoment(z) = stieltjeslegendremoment(0,z)
 
-logabslegendremoment(z) = real(z*log((z+1)/(z-1))+log(z^2-1)-2)
+logabslegendremoment(z) = real(z)*logabs((z+1)/(z-1))-imag(z)*angle((z+1)/(z-1))+logabs(z^2-1)-2
+                        # real(z*log((z+1)/(z-1)))+logabs(z^2-1)-2
 @vectorize_1arg Number logabslegendremoment
 
 #=
@@ -96,22 +97,4 @@ end
 =#
 
 
-function hilbertmoment(S::JacobiWeight,k::Integer,x)
-    x=tocanonical(S,x)
-
-    if S.α == 0 && S.β == 0.5
-        if k==1
-            if isapprox(x,1.0)
-                return 2*sqrt(2)/π
-            else
-                y=sqrt(-2/(x-1))
-                return (2*sqrt(2)-sqrt(2)*(log((1+y)/(y-1))/y))/π
-            end
-        elseif k==2
-
-        end
-    elseif S.α == 0.5 && S.β == 0.
-
-    end
-    (stieltjesmoment(true,S,k,x)+stieltjesmoment(false,S,k,x))/(2π)::Float64
-end
+hilbertmoment(S::Space,k::Integer,x) = -real(stieltjesmoment(S,k,x*⁺)+stieltjesmoment(S,k,x*⁻))/(2π)

--- a/src/stieltjesmoment.jl
+++ b/src/stieltjesmoment.jl
@@ -7,94 +7,28 @@
 cauchymoment(S...) = stieltjesmoment(S...)/(-2π*im)
 
 
-#=
-# gives \int_-1^1 x^(k-1)/(z-x) dx
-function stieltjeslegendremoment(k::Integer,z)
-    if k==1
-        return -(log(z-1)-log(z+1))
-    elseif k==2
-        return -(2-z*log(1+z)+z*log(z-1))
-    end
 
-    error("stieltjesmoment not implemented for "*string(S.a)*string(S.b))
-end
+stieltjesmoment{T,D}(S::WeightedJacobi{T,D},n::Int,z) = stieltjesjacobimoment(S.space.a,S.space.b,n,z)
+stieltjesmoment{T,D}(S::WeightedJacobi{T,D},z) = stieltjesjacobimoment(S.space.a,S.space.b,z)
 
-function stieltjeslegendremoment(k::Integer,z,s::Bool)
-    if k==1
-        return -(log(1-z)+(s?1:-1)*π*im-log(z+1))
-    elseif k==2
-        return -(2-z*log(1+z)+z*log(1-z) + (s?1:-1)*π*im*z)
-    end
+stieltjesmoment{T,D}(S::WeightedJacobiQ{T,D},n::Int,z) = stieltjesjacobimoment(S.space.a,S.space.b,n,z)
+stieltjesmoment{T,D}(S::WeightedJacobiQ{T,D},z) = stieltjesjacobimoment(S.space.a,S.space.b,z)
 
-    error("stieltjesmoment not implemented for "*string(S.a)*string(S.b))
-end
-
-
-stieltjesmoment(S::Chebyshev,k::Integer,z)=stieltjeslegendremoment(k,tocanonical(S,z))
-function stieltjesmoment(J::Jacobi,k::Integer,z)
-    if k==1
-        return stieltjeslegendremoment(k,z)
-    elseif k==2
-        if J.a==J.b
-            return (1+J.a)*stieltjeslegendremoment(k,z)
-        else
-            return (J.b-J.a)/2*stieltjeslegendremoment(1,z) + (2+J.a+J.b)/2*stieltjeslegendremoment(2,z)
-        end
-    end
-
-    error("Not implemented")
-end
-
-function stieltjesmoment(S::PolynomialSpace,k::Integer,z,s::Bool)
-    z=tocanonical(S,z)
-
-    if k==1
-        return -(log(1-z)+(s?1:-1)*π*im-log(z+1))
-    elseif k==2
-        return -(2-z*log(1+z)+z*log(1-z) + (s?1:-1)*π*im*z)
-    end
-
-    error("stieltjesmoment not implemented for "*string(S.a)*string(S.b))
-end
-
-
-# represents atan(sqrt(z))/sqrt(z)
-function sqrtatansqrt(x)
-    if  isreal(x) && x ≤ 0
-        y=sqrt(-x)
-        log((1+y)/(1-y))/(2y)
-    else
-        sqrt(1/x)*atan(sqrt(x))
-    end
-end
-
-function sqrtatansqrt(x,s::Bool)
-    y=sqrt(-x)
-    (log((1+y)/(y-1))-(s?1:-1)*π*im)/(2y)
-end
-=#
-
-stieltjesmoment{T,D}(S::WeightedJacobi{T,D},n::Int,z,s...) = stieltjesjacobimoment(S.space.a,S.space.b,n,z,s...)
-stieltjesmoment{T,D}(S::WeightedJacobi{T,D},z,s...) = stieltjesjacobimoment(S.space.a,S.space.b,z,s...)
-
-stieltjesmoment{T,D}(S::WeightedJacobiQ{T,D},n::Int,z,s...) = stieltjesjacobimoment(S.space.a,S.space.b,n,z,s...)
-stieltjesmoment{T,D}(S::WeightedJacobiQ{T,D},z,s...) = stieltjesjacobimoment(S.space.a,S.space.b,z,s...)
-
-stieltjesmoment(S::Jacobi,n::Int,z,s...) = stieltjesjacobimoment(S.a,S.b,n,z,s...)
-stieltjesmoment(S::Jacobi,z,s...) = stieltjesjacobimoment(S.a,S.b,z,s...)
-stieltjesmoment(S::JacobiQ,n::Int,z,s...) = stieltjesjacobimoment(S.a,S.b,n,z,s...)
-stieltjesmoment(S::JacobiQ,z,s...) = stieltjesjacobimoment(S.a,S.b,z,s...)
+stieltjesmoment(S::Jacobi,n::Int,z) = stieltjesjacobimoment(S.a,S.b,n,z)
+stieltjesmoment(S::Jacobi,z) = stieltjesjacobimoment(S.a,S.b,z)
+stieltjesmoment(S::JacobiQ,n::Int,z) = stieltjesjacobimoment(S.a,S.b,n,z)
+stieltjesmoment(S::JacobiQ,z) = stieltjesjacobimoment(S.a,S.b,z)
 
 normalization(n::Int,α::Real,β::Real) = 2^(α+β)*gamma(n+α+1)*gamma(n+β+1)/gamma(2n+α+β+2)
-stieltjesjacobimoment(α::Real,β::Real,n::Int,z,s...) =
-    (x = 2./(1-z);normalization(n,α,β)*(-x).^(n+1).*_₂F₁(n+1,n+α+1,2n+α+β+2,x,s...))
+stieltjesjacobimoment(α::Real,β::Real,n::Int,z) =
+    (x = 2./(1-z);normalization(n,α,β)*(-x).^(n+1).*_₂F₁(n+1,n+α+1,2n+α+β+2,x))
 stieltjesjacobimoment(α::Real,β::Real,z) = stieltjesjacobimoment(α,β,0,z)
 
 
-function logjacobimoment(α::Real,β::Real,n::Int,z,s...)
+function logjacobimoment(α::Real,β::Real,n::Int,z)
     x = 2./(1-z)
     if n == 0
-        2normalization(0,α,β)*(log(z-1)-dualpart(_₂F₁(dual(zero(α)+eps(α+β),one(β)),α+1,α+β+2,x,s...)))
+        2normalization(0,α,β)*(log(z-1)-dualpart(_₂F₁(dual(zero(α)+eps(α+β),one(β)),α+1,α+β+2,x)))
         # For testing purposes only, should be equivalent to above within radius of convergence
         #2normalization(0,α,β)*(log(z-1)-(α+1)/(α+β+2)*x.*_₃F₂(α+2,α+β+3,x))
     else
@@ -166,20 +100,20 @@ function stieltjesjacobimoment(α,β,k::Integer,z,s::Bool)
 end
 
 
-stieltjesmoment{DD}(S::JacobiWeight{Chebyshev{DD},DD},k::Integer,z,s...)=stieltjesjacobimoment(S.α,S.β,k,tocanonical(S,z),s...)
+stieltjesmoment{DD}(S::JacobiWeight{Chebyshev{DD},DD},k::Integer,z)=stieltjesjacobimoment(S.α,S.β,k,tocanonical(S,z))
 
 
-function stieltjesmoment{T,DD}(S::JacobiWeight{Jacobi{T,DD},DD},k::Integer,z,s...)
+function stieltjesmoment{T,DD}(S::JacobiWeight{Jacobi{T,DD},DD},k::Integer,z)
     z=tocanonical(S,z)
     J=S.space
 
     if k==1
-        return stieltjesjacobimoment(S.α,S.β,k,z,s...)
+        return stieltjesjacobimoment(S.α,S.β,k,z)
     elseif k==2
         if J.a==J.b
-            return (1+J.a)*stieltjesjacobimoment(S.α,S.β,k,z,s...)
+            return (1+J.a)*stieltjesjacobimoment(S.α,S.β,k,z)
         else
-            return (J.a-J.b)/2*stieltjesjacobimoment(S.α,S.β,1,z,s...) + (2+J.a+J.b)/2*stieltjesjacobimoment(S.α,S.β,2,z,s...)
+            return (J.a-J.b)/2*stieltjesjacobimoment(S.α,S.β,1,z) + (2+J.a+J.b)/2*stieltjesjacobimoment(S.α,S.β,2,z)
         end
     end
     error("stieltjesmoment not implemented for JacobiWeight "*string(S.α)*string(S.β))

--- a/src/stieltjesmoment.jl
+++ b/src/stieltjesmoment.jl
@@ -74,31 +74,6 @@ end
 
 
 
-function stieltjesjacobimoment(α,β,k::Integer,z,s::Bool)
-    if α == β == 0
-        return stieltjeslegendremoment(k,z,s)
-    elseif isapprox(α,0) && isapprox(β,0.5)
-        if k==1
-            return -2*sqrt(2)*(sqrtatansqrt(2/(z-1))-1,!s)
-        elseif k==2
-            return 2*sqrt(2)*(1/3*(3z-2)-z*sqrtatansqrt(2/(z-1),!s))
-        end
-    elseif isapprox(α,0) && isapprox(β,-0.5)
-        if k==1
-            return 2im*(s?-1:1)*sqrt(1/(1-z))*atan((s?-1:1)*im*sqrt(2/(1-z)))
-        elseif k==2 && real(z)<0
-            return z/sqrt(1-z)*(logabs((1+1/sqrt(1-z))*(1-sqrt(2)/sqrt(1-z))/((1-1/sqrt(1-z))*(1+sqrt(2)/sqrt(1-z))))-π*im*(s?1:-1))-
-                            2*sqrt(2)-2z/sqrt(1-z)*asinh(sqrt(-1/z))
-        elseif k==2
-            return z/sqrt(1-z)*log((1+1/sqrt(1-z))*(1-sqrt(2)/sqrt(1-z))/((1-1/sqrt(1-z))*(1+sqrt(2)/sqrt(1-z))))-
-                             2*sqrt(2)-2z/sqrt(1-z)*asinh(im*(s?1:-1)*sqrt(1/z))
-        end
-    elseif !isapprox(α,0) && isapprox(β,0.)
-        return (-1)^k*stieltjesjacobimoment(β,α,k,-z,!s)
-    end
-    error("stieltjesmoment not implemented for JacobiWeight "*string(α)*string(β))
-end
-
 
 stieltjesmoment{DD}(S::JacobiWeight{Chebyshev{DD},DD},k::Integer,z)=stieltjesjacobimoment(S.α,S.β,k,tocanonical(S,z))
 

--- a/src/vectorcauchy.jl
+++ b/src/vectorcauchy.jl
@@ -1,10 +1,10 @@
 # I think it makes more sense to let the array into the function.
 # That way the coefficient conversions happen once.
 #=
-function cauchy{S,T}(f::Fun{S,T},z::Array,s...)
+function cauchy{S,T}(f::Fun{S,T},z::Array)
     ret=Array(Complex{Float64},size(z)...)
     for k=1:size(z,1),j=1:size(z,2)
-        @inbounds ret[k,j]=cauchy(f,z[k,j],s...)
+        @inbounds ret[k,j]=cauchy(f,z[k,j])
     end
     ret
 end
@@ -30,7 +30,7 @@ hilbert(S::PiecewiseSpace,v,z)=hilbert(pieces(Fun(v,S)),z)
 
 
 
-function cauchy{S<:ArraySpace,T}(v::Fun{S,T},z::Number,s...)
+function cauchy{S<:ArraySpace,T}(v::Fun{S,T},z::Number)
     m=mat(v)
-    Complex{Float64}[cauchy(m[k,j],z,s...) for k=1:size(m,1),j=1:size(m,2)]
+    Complex{Float64}[cauchy(m[k,j],z) for k=1:size(m,1),j=1:size(m,2)]
 end

--- a/src/vectorcauchy.jl
+++ b/src/vectorcauchy.jl
@@ -12,21 +12,23 @@ end
 
 for op in (:(stieltjes),:(cauchy),:(logkernel),:(stieltjesintegral),:(cauchyintegral))
     @eval begin
-        $op{F<:Fun}(v::Vector{F},z)=mapreduce(f->$op(f,z),+,v)
-        $op{F<:Fun}(v::Vector{F})=map($op,v)
-        $op(v::Vector{Any},z)=mapreduce(f->$op(f,z),+,v)
-        $op(S::PiecewiseSpace,v,z)=$op(pieces(Fun(v,S)),z)
+        $op{F<:Fun}(v::Vector{F},z) = mapreduce(f->$op(f,z),+,v)
+        $op{F<:Fun}(v::Vector{F}) = map($op,v)
+        $op(v::Vector{Any},z) = mapreduce(f->$op(f,z),+,v)
+        $op(S::PiecewiseSpace,v,z) = $op(pieces(Fun(v,S)),z)
         $op{S<:PiecewiseSpace,T}(f::Fun{S,T}) = (v = $op(pieces(f)); Fun(vec(coefficientmatrix(v).'),ApproxFun.SumSpace(map(space,v))))
-        $op(S::PiecewiseSpace,v)=depiece($op(pieces(Fun(v,S))))
+        $op(S::PiecewiseSpace,v) = depiece($op(pieces(Fun(v,S))))
 
-        $op{F<:Fun}(v::Vector{F},z,s::Bool)=mapreduce(f->(z in domain(f))?$op(f,z,s):$op(f,z),+,v)
-        $op(v::Vector{Any},z,s::Bool)=mapreduce(f->(z in domain(f))?$op(f,z,s):$op(f,z),+,v)
-        $op(S::PiecewiseSpace,v,z,s::Bool)=$op(pieces(Fun(v,S)),z,s)
+        # directed is usually analytic continuation, so we need to unwrap
+        # directd
+        $op{F<:Fun}(v::Vector{F},z::Directed) = mapreduce(f->(z in domain(f))?$op(f,z):$op(f,z.x),+,v)
+        $op(v::Vector{Any},z::Directed) = mapreduce(f->(z in domain(f))?$op(f,z):$op(f,z.x),+,v)
     end
 end
 
-hilbert{F<:Union{Fun,Any}}(v::Vector{F},x)=mapreduce(f->(x in domain(f))?hilbert(f,x):-stieltjes(f,x)/π,+,v)
-hilbert(S::PiecewiseSpace,v,z)=hilbert(pieces(Fun(v,S)),z)
+hilbert{F<:Union{Fun,Any}}(v::Vector{F},x) =
+    mapreduce(f->(x in domain(f))?hilbert(f,x):-stieltjes(f,x)/π,+,v)
+hilbert(S::PiecewiseSpace,v,z) = hilbert(pieces(Fun(v,S)),z)
 
 
 

--- a/test/HilbertTest.jl
+++ b/test/HilbertTest.jl
@@ -1,12 +1,13 @@
 using Base.Test, ApproxFun, SingularIntegralEquations
     import ApproxFun: ∞, testbandedoperator, testfunctional, testbandedblockoperator, testraggedbelowoperator
-    import SingularIntegralEquations: testsies
+    import SingularIntegralEquations: testsies, ⁺, mobius, joukowskyinverse, sqrtx2, Directed
+
 
 ## Sqrt singularity
 
-S=JacobiWeight(0.5,0.5,Ultraspherical(1,[-2.,-1.]))
+Directed{true,Float64}(1.0)
 
-@test rangespace(SingularIntegral(S,0))==Chebyshev([-2.,-1.])
+S=JacobiWeight(0.5,0.5,Ultraspherical(1,[-2.,-1.]))
 
 testsies(S)
 

--- a/test/HilbertTest.jl
+++ b/test/HilbertTest.jl
@@ -249,7 +249,7 @@ f=Fun(exp,a)*sqrt(abs((ζ-1)*(ζ-im)))
 z=.1+.2im
 #@test_approx_eq cauchy(f,z) sum(f/(ζ-z))/(2π*im)
 z=exp(.1im)
-@test_approx_eq hilbert(f,z) im*(cauchy(f,z,+)+cauchy(f,z,-))
+@test_approx_eq hilbert(f,z) im*(cauchy(f,z*⁺)+cauchy(f,z*⁻))
 
 
 

--- a/test/HilbertTest.jl
+++ b/test/HilbertTest.jl
@@ -1,14 +1,14 @@
 using Base.Test, ApproxFun, SingularIntegralEquations
     import ApproxFun: ∞, testbandedoperator, testfunctional, testbandedblockoperator, testraggedbelowoperator
-    import SingularIntegralEquations: testsies, ⁺, mobius, joukowskyinverse, sqrtx2, Directed
+    import SingularIntegralEquations: testsies, ⁺, ⁻, mobius, joukowskyinverse, sqrtx2, Directed
 
 
 ## Sqrt singularity
 
-Directed{true,Float64}(1.0)
+S=JacobiWeight(0.5,0.5,Ultraspherical(1))
+testsies(S)
 
 S=JacobiWeight(0.5,0.5,Ultraspherical(1,[-2.,-1.]))
-
 testsies(S)
 
 f=Fun(x->exp(x)*sqrt(x+2)*sqrt(-1-x),S)

--- a/test/HilbertTest.jl
+++ b/test/HilbertTest.jl
@@ -227,9 +227,7 @@ testbandedoperator(Cauchy(d1,d2))
 
 #Legendre uses FastGaussQuadrature
 f=Fun(exp,Legendre())
-#@test_approx_eq cauchy(f,.1+0.000000000001im) cauchy(f,.1,+)
-#@test_approx_eq cauchy(f,.1-0.000000000001im) cauchy(f,.1,-)
-#@test_approx_eq (cauchy(f,.1,+)-cauchy(f,.1,-)) exp(.1)
+
 
 ω=2.
 d=Interval(0.5im,30.0im/ω)

--- a/test/WienerHopfTest.jl
+++ b/test/WienerHopfTest.jl
@@ -95,11 +95,12 @@ z=exp(0.1im)
 @test_approx_eq Φp(z) (I+cauchy(V,z*⁺))
 @test_approx_eq Φp(z)*inv(Φmi(z)) G(z)
 
-@test_approx_eq inv(Φmi)(z) inv(Φmi(z))
+Φm=inv.(Φmi)
+@test_approx_eq Φm(z) inv(Φmi(z))
 
 T=ToeplitzOperator(G)
 
-L  = ToeplitzOperator(inv(Φmi))
+L  = ToeplitzOperator(Φm)
 U  = ToeplitzOperator(Φp)
 
 @test norm((T-U*L)[1:10,1:10]) < 100eps()  # check the accuracy

--- a/test/WienerHopfTest.jl
+++ b/test/WienerHopfTest.jl
@@ -1,5 +1,5 @@
 using ApproxFun, SingularIntegralEquations, Base.Test
-
+    import SingularIntegralEquations: ⁻, ⁺
 
 # Scalar case
 
@@ -36,8 +36,8 @@ F=Fun((G-I)[:,1])
 
 @test norm((C*F - [C*F[1];C*F[2]]).coefficients) == 0
 @test norm((C*G - [C*G[1] C*G[3];C*G[2] C*G[4]]).coefficients) == 0
-@test_approx_eq cauchy(F,exp(0.1im),-) (C*F)(exp(0.1im))
-@test_approx_eq cauchy(G,exp(0.1im),-) (C*G)(exp(0.1im))
+@test_approx_eq cauchy(F,exp(0.1im)⁻) (C*F)(exp(0.1im))
+@test_approx_eq cauchy(G,exp(0.1im)⁻) (C*G)(exp(0.1im))
 
 
 
@@ -80,19 +80,19 @@ V2  = A\(G-I)[:,2]
 @test norm((A*V[:,1]-(G[:,1]-[1,0])).coefficients) < 100eps()
 
 z=exp(0.1im)
-@test_approx_eq V(z)+(I-G(z))*cauchy(V,z,-) G(z)-I
+@test_approx_eq V(z)+(I-G(z))*cauchy(V,z*⁻) G(z)-I
 
-@test_approx_eq cauchy(V[1,1],exp(0.1im),-) (C*V[1,1])(exp(0.1im))
-@test_approx_eq cauchy(V[2,1],exp(0.1im),-) (C*V[2,1])(exp(0.1im))
-@test_approx_eq cauchy(V[:,1],exp(0.1im),-) (C*V[:,1])(exp(0.1im))
-@test_approx_eq cauchy(V,exp(0.1im),-) (C*V)(exp(0.1im))
+@test_approx_eq cauchy(V[1,1],exp(0.1im)⁻) (C*V[1,1])(exp(0.1im))
+@test_approx_eq cauchy(V[2,1],exp(0.1im)⁻) (C*V[2,1])(exp(0.1im))
+@test_approx_eq cauchy(V[:,1],exp(0.1im)⁻) (C*V[:,1])(exp(0.1im))
+@test_approx_eq cauchy(V,exp(0.1im)⁻) (C*V)(exp(0.1im))
 
 Φmi = I+C*V
 Φp = V+Φmi
 
 
-@test_approx_eq Φmi(z) (I+cauchy(V,z,-))
-@test_approx_eq Φp(z) (I+cauchy(V,z,+))
+@test_approx_eq Φmi(z) (I+cauchy(V,z*⁻))
+@test_approx_eq Φp(z) (I+cauchy(V,z*⁺))
 @test_approx_eq Φp(z)*inv(Φmi(z)) G(z)
 
 @test_approx_eq inv(Φmi)(z) inv(Φmi(z))

--- a/test/logkerneltest.jl
+++ b/test/logkerneltest.jl
@@ -97,8 +97,4 @@ f=(1-x)^(-0.1)*(1+x)^(-0.2)*exp(x)
 
 ## Arc
 a=Arc(0.,1.,0.,π/2)
-ζ=Fun(identity,a)
-f=real(exp(ζ))
-@which stieltjes(ApproxFun.setcanonicaldomain(space(f)),f.coefficients,exp(0.1im))
-@which hilbert(space(f),f.coefficients,exp(0.1im))
-testsieeval(space(f))
+testsieeval(Legendre(a);posdirection=(-1-im))

--- a/test/logkerneltest.jl
+++ b/test/logkerneltest.jl
@@ -1,23 +1,9 @@
 using Base.Test, ApproxFun, SingularIntegralEquations
     import ApproxFun: ∞, testbandedoperator, testfunctional, testbandedblockoperator, testraggedbelowoperator, JacobiZ
-    import SingularIntegralEquations: testsies, testsieeval, stieltjesmoment, Directed, _₂F₁, ⁺, value
+    import SingularIntegralEquations: testsies, testsieeval, stieltjesmoment, Directed, _₂F₁, ⁺, ⁻, value
 
 
 testsieeval(Jacobi(0,0))
-
-
-f=Fun(exp,Legendre())
-cauchy(f,0.1,true)-cauchy(f,0.1,false)
-
-
-
-cauchy(f,0.1,true)
-
-cauchy(f,0.1+0.00000001im)
-
-exp(0.1)
-(cauchy(Jacobi(0,0),a,0.1,true)-cauchy(Jacobi(0,0),a,0.1,false))
-
 
 a=1.0;b=2.0+im
 d=Interval(a,b)
@@ -116,6 +102,3 @@ f=real(exp(ζ))
 @which stieltjes(ApproxFun.setcanonicaldomain(space(f)),f.coefficients,exp(0.1im))
 @which hilbert(space(f),f.coefficients,exp(0.1im))
 testsieeval(space(f))
-plot(a)
-
-cauchy(f,)

--- a/test/logkerneltest.jl
+++ b/test/logkerneltest.jl
@@ -1,11 +1,9 @@
 using Base.Test, ApproxFun, SingularIntegralEquations
-    import ApproxFun: ∞, testbandedoperator, testfunctional, testbandedblockoperator, testraggedbelowoperator
-    import SingularIntegralEquations: testsies, testsieeval
+    import ApproxFun: ∞, testbandedoperator, testfunctional, testbandedblockoperator, testraggedbelowoperator, JacobiZ
+    import SingularIntegralEquations: testsies, testsieeval, stieltjesmoment, Directed, _₂F₁, ⁺, value
 
 
 testsieeval(Jacobi(0,0))
-
-@which stieltjes(Jacobi(0,0),rand(5),0.1+0.2im)
 
 
 f=Fun(exp,Legendre())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,18 @@
 using ApproxFun, SingularIntegralEquations, Base.Test
+    import SingularIntegralEquations: x̄sqrtx2real, sqrtx2, joukowskyinverse,
+            joukowskyinversereal, joukowskyinverseabs
+
+## Special functions
+
+println("Special function tests")
+
+@test_approx_eq x̄sqrtx2real(2.0+3.0im) real(sqrtx2(2.0+3.0im)*(2.0-3.0im))
+
+for s in (true,false), z in (2.0+3.0im,2.0,0.1)
+    @test_approx_eq real(joukowskyinverse(Val{s},z+0im)) joukowskyinversereal(Val{s},z)
+    @test_approx_eq abs(joukowskyinverse(Val{s},z+0im)) joukowskyinverseabs(Val{s},z)
+end
+
 
 println("Hilbert test")
 include("HilbertTest.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,21 @@
 using ApproxFun, SingularIntegralEquations, Base.Test
     import SingularIntegralEquations: x̄sqrtx2real, sqrtx2, joukowskyinverse,
             joukowskyinversereal, joukowskyinverseabs, ⁺, ⁻, logabslegendremoment,
-            stieltjeslegendremoment, stieltjesjacobimoment, stieltjesmoment, Directed
+            stieltjeslegendremoment, stieltjesjacobimoment, stieltjesmoment, Directed,
+            HypergeometricFunctions
+    import HypergeometricFunctions: _₂F₁general,_₂F₁Inf
+
 
 ## Special functions
 
 println("Special function tests")
+
+
+for (a,b,c) in ((1,1,2),(2,2,4)), x in (1.1,10.1,1.5)
+    @test_approx_eq _₂F₁(a,b,c,x+eps()im) _₂F₁(a,b,c,x*⁺)
+    @test_approx_eq _₂F₁(a,b,c,x-eps()im) _₂F₁(a,b,c,x*⁻)
+end
+
 
 @test_approx_eq x̄sqrtx2real(2.0+3.0im) real(sqrtx2(2.0+3.0im)*(2.0-3.0im))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ApproxFun, SingularIntegralEquations, Base.Test
     import SingularIntegralEquations: x̄sqrtx2real, sqrtx2, joukowskyinverse,
-            joukowskyinversereal, joukowskyinverseabs
+            joukowskyinversereal, joukowskyinverseabs, ⁺, ⁻
 
 ## Special functions
 
@@ -8,9 +8,15 @@ println("Special function tests")
 
 @test_approx_eq x̄sqrtx2real(2.0+3.0im) real(sqrtx2(2.0+3.0im)*(2.0-3.0im))
 
-for s in (true,false), z in (2.0+3.0im,2.0,0.1)
-    @test_approx_eq real(joukowskyinverse(Val{s},z+0im)) joukowskyinversereal(Val{s},z)
-    @test_approx_eq abs(joukowskyinverse(Val{s},z+0im)) joukowskyinverseabs(Val{s},z)
+for s in (true,false)
+    for z in (2.0+3.0im,2.0,0.1)
+        @test_approx_eq real(joukowskyinverse(Val{s},z+0im)) joukowskyinversereal(Val{s},z)
+        @test_approx_eq abs(joukowskyinverse(Val{s},z+0im)) joukowskyinverseabs(Val{s},z)
+    end
+
+    p=0.1
+    @test_approx_eq joukowskyinverse(Val{s},p*⁺) joukowskyinverse(Val{s},p+0im)
+    @test_approx_eq joukowskyinverse(Val{s},p*⁻) joukowskyinverse(Val{s},p-0im)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ApproxFun, SingularIntegralEquations, Base.Test
     import SingularIntegralEquations: x̄sqrtx2real, sqrtx2, joukowskyinverse,
-            joukowskyinversereal, joukowskyinverseabs, ⁺, ⁻
+            joukowskyinversereal, joukowskyinverseabs, ⁺, ⁻, logabslegendremoment,
+            stieltjeslegendremoment, stieltjesjacobimoment, stieltjesmoment, Directed
 
 ## Special functions
 
@@ -19,6 +20,18 @@ for s in (true,false)
     @test_approx_eq joukowskyinverse(Val{s},p*⁻) joukowskyinverse(Val{s},p-0im)
 end
 
+
+x=Fun()
+@test_approx_eq sum(log(abs(x-2.0))) logabslegendremoment(2.0)
+@test_approx_eq sum(log(abs(x-(2.0+im)))) logabslegendremoment(2.0+im)
+
+@test_approx_eq stieltjesmoment(Legendre(),0,0.1+0im) stieltjesmoment(Legendre(),0,Directed{true}(0.1))
+@test_approx_eq stieltjesmoment(Legendre(),0,0.1-0im) stieltjesmoment(Legendre(),0,Directed{false}(0.1))
+@test_approx_eq stieltjesjacobimoment(0.,0.,1,0.1+0im) stieltjesjacobimoment(0.,0.,1,0.1*⁺)
+@test_approx_eq stieltjesjacobimoment(0.,0.,1,0.1-0im) stieltjesjacobimoment(0.,0.,1,0.1*⁻)
+
+@test_approx_eq (stieltjesjacobimoment(0,0,0,0.1+0im)-stieltjesjacobimoment(0,0,0,0.1-0im))/(-2π*im) 1.0
+@test_approx_eq (stieltjesjacobimoment(0,0,1,0.1+0im)-stieltjesjacobimoment(0,0,1,0.1-0im))/(-2π*im) 0.1
 
 println("Hilbert test")
 include("HilbertTest.jl")


### PR DESCRIPTION
This removes the old cauchy(f,0.1,+) syntax in favour of cauchy(f,0.1⁺).  It uses a special type `Directed` and overloading, avoiding the need for different implementations.  (A la automatic differentiation.)

Note that there may be an alternative implementation based on dual numbers, where instead of left/right the number has a direction.  It wouldn't work at the moment since `sqrt(dual(-1.0,-1.0im))` does not give the branch dictated by the dual part.  