### PR TITLE
Call `domain(sp)` rather than `domain(cfs)` in PeriodicLine hilbert

### DIFF
--- a/src/periodicline.jl
+++ b/src/periodicline.jl
@@ -11,7 +11,7 @@ end
 
 function hilbert(S::Space{<:PeriodicLine},f::AbstractVector,z::Number)
     S2=setdomain(S,Circle())
-    hilbert(S2,f,mappoint(domain(f),Circle(),z))-hilbert(S2,f,-1)
+    hilbert(S2,f,mappoint(domain(S),Circle(),z))-hilbert(S2,f,-1)
 end
 
 function stieltjes(S::SumSpace{<:Any,<:PeriodicLine},f::AbstractVector,z::Number)
@@ -21,7 +21,7 @@ end
 
 function hilbert(S::SumSpace{<:Any,<:PeriodicLine},f::AbstractVector,z::Number)
     S2=setdomain(S,Circle())
-    hilbert(S2,f,mappoint(domain(f),Circle(),z))-hilbert(S2,f,-1)
+    hilbert(S2,f,mappoint(domain(S),Circle(),z))-hilbert(S2,f,-1)
 end
 
 


### PR DESCRIPTION
This addresses https://github.com/JuliaApproximation/SingularIntegralEquations.jl/issues/152 by correcting calls of `domain(f::AbstractVector)` to `domain(S::Space)` in `hilbert(S::Space{<:PeriodicLine},f::AbstractVector,z::Number)`

Is it worth adding tests? e.g.

```julia
using ApproxFun, SingularIntegralEquations, Test
F = Fun(z->1/(1+z^2),PeriodicLine())
hilbertF = z-> -z/(1+z^2)
z = pi
@test hilbert(F,z) ≈ hilbertF(z)

```